### PR TITLE
Move specification of codacy dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
     install_requires=GENERIC_REQ,
     setup_requires=['pytest-runner', 'wheel', 'setuptools_git >= 0.3'],
     extras_require={
-        "dev": TESTS_REQ + CODE_QUALITY_REQ
+        "dev": TESTS_REQ + CODE_QUALITY_REQ,
+        "codacy": ["codacy-coverage"]
     },
 
     # Metadata

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,7 @@ commands=prospector
 
 [testenv:coverage]
 usedevelop=True
-deps=-rrequirements.txt
-     codacy-coverage
+deps=.[dev,codacy]
 passenv =
     HOME
     CODACY_PROJECT_TOKEN


### PR DESCRIPTION
Making sure all deps are specified in one place, but using the "extras" feature of setuptools more.
