### PR TITLE
Release scripts

### DIFF
--- a/bin/get_github_release.py
+++ b/bin/get_github_release.py
@@ -26,13 +26,8 @@ def main():
 
 
 def _unpack(tmp_dir, asset_path):
-    old_dir = os.getcwd()
-    os.chdir(tmp_dir)
-    try:
-        output = subprocess.check_output(["tar", "xjvf", asset_path])
-        return os.path.join(tmp_dir, output.strip())
-    finally:
-        os.chdir(old_dir)
+    output = subprocess.check_output(["tar", "--directory", tmp_dir, "xjvf", asset_path])
+    return os.path.join(tmp_dir, output.strip())
 
 
 def _download_asset(asset_url):
@@ -54,11 +49,17 @@ def _get_release_info():
 
 
 def _find_wanted_asset(release_info):
+    names = list()
     for asset in release_info["assets"]:
-        m = ASSET_NAME_PATTERN.match(asset["name"])
+        name = asset["name"]
+        names.append(name)
+        m = ASSET_NAME_PATTERN.match(name)
         if m:
             return asset["browser_download_url"]
-    raise RuntimeError("Unable to find an asset matching {!r}".format(ASSET_NAME_PATTERN.pattern))
+    raise RuntimeError("No asset in {} matches {!r}".format(
+        ", ".join(names),
+        ASSET_NAME_PATTERN.pattern
+    ))
 
 
 if __name__ == "__main__":

--- a/bin/get_github_release.py
+++ b/bin/get_github_release.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+"""Download the latest version of github-release and place in a temporary location"""
+
+from __future__ import unicode_literals, print_function
+
+import platform
+import subprocess
+import tempfile
+
+import os
+import re
+import requests
+
+URL = "https://api.github.com/repos/aktau/github-release/releases/latest"
+ASSET_NAME_PATTERN = re.compile(r"^{}-amd64-github-release\.tar\.bz2$".format(platform.system().lower()))
+
+
+def main():
+    release_info = _get_release_info()
+    asset_url = _find_wanted_asset(release_info)
+    tmp_dir, asset_path = _download_asset(asset_url)
+    bin_path = _unpack(tmp_dir, asset_path)
+    print(bin_path)
+
+
+def _unpack(tmp_dir, asset_path):
+    old_dir = os.getcwd()
+    os.chdir(tmp_dir)
+    try:
+        output = subprocess.check_output(["tar", "xjvf", asset_path])
+        return os.path.join(tmp_dir, output.strip())
+    finally:
+        os.chdir(old_dir)
+
+
+def _download_asset(asset_url):
+    resp = requests.get(asset_url)
+    resp.raise_for_status()
+    tmp_dir = tempfile.mkdtemp(prefix="github-release-")
+    fpath = os.path.join(tmp_dir, "github-release")
+    with open(fpath, "wb") as fobj:
+        for chunk in resp.iter_content(chunk_size=8192):
+            fobj.write(chunk)
+    return tmp_dir, fpath
+
+
+def _get_release_info():
+    resp = requests.get(URL)
+    resp.raise_for_status()
+    release_info = resp.json()
+    return release_info
+
+
+def _find_wanted_asset(release_info):
+    for asset in release_info["assets"]:
+        m = ASSET_NAME_PATTERN.match(asset["name"])
+        if m:
+            return asset["browser_download_url"]
+    raise RuntimeError("Unable to find an asset matching {!r}".format(ASSET_NAME_PATTERN.pattern))
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/release.py
+++ b/bin/release.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+"""Release a new version of the k8s library
+
+Script is assumed to be run using Semaphore CI to release a version from a
+successful build.
+
+To release a new version, create a git annotated tag named v<major>.<minor>.<patch>,
+according to Semantic Versioning principles. After you have pushed the tag, CI will
+build the commit, and then run this script to deploy a release.
+
+The script will do the following steps:
+- Check if the build refers exactly to an annotated tag following the convention above
+- Generate a suitable changelog
+- Create packages for upload (wheels and tarballs)
+- Use https://github.com/aktau/github-release to create a Github release
+- Use the projects setup.py to create a PyPi release
+"""
+from __future__ import unicode_literals, print_function
+
+import argparse
+import subprocess
+import tempfile
+
+import os
+import re
+from git import Repo, BadName, GitCommandError
+from git.cmd import Git
+
+# Magical, always present, empty tree reference
+# https://stackoverflow.com/questions/9765453/
+THE_NULL_COMMIT = Git().hash_object(os.devnull, t="tree")
+
+
+class Formatter(argparse.RawDescriptionHelpFormatter, argparse.ArgumentDefaultsHelpFormatter):
+    pass
+
+
+class Repository(object):
+    RELEASE_TAG_PATTERN = re.compile(r"^v\d+(\.\d+){0,2}$")
+
+    def __init__(self, options):
+        self.repo = Repo(options.directory)
+        self._force = options.force
+        self._current_tag = None
+
+    @property
+    def current_tag(self):
+        if self._current_tag:
+            return self._current_tag
+        try:
+            current_name = self.repo.git.describe(all=True)
+            self._current_tag = self.repo.rev_parse(current_name)
+            return self._current_tag
+        except BadName:
+            return None
+
+    def ready_for_release(self):
+        """Return true if the current git checkout is suitable for release
+
+        To be suitable, it must not be dirty, must not have untracked files, must be an annotated tag,
+        and the tag must follow the naming convention v<major>.<minor>.<bugfix>
+        """
+        if self._force:
+            return True
+        if self.repo.is_dirty() or self.repo.untracked_files or not self.current_tag:
+            return False
+        return self.RELEASE_TAG_PATTERN.match(self.current_tag.tag) is not None
+
+    def generate_changelog(self):
+        """Use the git log to create a changelog with all changes since the previous tag"""
+        try:
+            previous_name = self.repo.git.describe("{}^".format(self.current_tag), abbrev=0)
+            previous_tag = self.repo.rev_parse(previous_name)
+        except GitCommandError:
+            previous_tag = THE_NULL_COMMIT
+        commits = list(self.repo.iter_commits("{}..{}".format(previous_tag, self.current_tag)))
+        return ["{} {}".format(commit.hexsha, commit.summary) for commit in commits]
+
+
+def format_rst_changelog(changelog):
+    return "\n".join(changelog)
+
+
+def create_artifacts(changelog):
+    """List all artifacts for uploads
+
+    Wheels and tarballs
+    """
+    fd, name = tempfile.mkstemp(prefix="changelog", suffix=".rst", text=True)
+    with os.fdopen(fd, "w") as fobj:
+        fobj.write(format_rst_changelog(changelog))
+    subprocess.check_call(["python", "setup.py", "sdist", "bdist_wheel", "--universal"], env={"CHANGELOG_FILE": name})
+    return [os.path.abspath(os.path.join("dist", fname)) for fname in os.listdir("dist")]
+
+
+def github_release(changelog, artifacts):
+    """Create release in github.com, and upload artifacts and changelog"""
+    pass
+
+
+def pypi_release(artifacts):
+    """Create release in pypi.python.org, and upload artifacts and changelog"""
+    pass
+
+
+def main(options):
+    repo = Repository(options)
+    if not repo.ready_for_release():
+        print("Repository is not ready for release")
+        return
+    changelog = repo.generate_changelog()
+    artifacts = create_artifacts(changelog)
+    print("==== Ready to create release ====")
+    print("---- Changelog ----")
+    print("\n".join(changelog))
+    print("---- Artifacts ----")
+    print("\n".join(artifacts))
+    print("-" * 40)
+    github_release(changelog, artifacts)
+    pypi_release(artifacts)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=Formatter)
+    parser.add_argument("-d", "--directory", default=".", help="Git repository")
+    parser.add_argument("-f", "--force", action="store_true", help="Make a release even if the repo is unclean")
+    parser.add_argument("-n", "--dry-run", action="store_true", help="Do everything, except upload to GH/PyPI")
+    options = parser.parse_args()
+    main(options)

--- a/bin/release.py
+++ b/bin/release.py
@@ -23,7 +23,6 @@ import argparse
 import subprocess
 import sys
 import tempfile
-import textwrap
 
 import os
 import re
@@ -35,6 +34,12 @@ from git.cmd import Git
 THE_NULL_COMMIT = Git().hash_object(os.devnull, t="tree")
 
 ISSUE_NUMBER = re.compile(r"#(\d+)")
+
+CHANGELOG_HEADER = """
+Changes since last version
+--------------------------
+
+"""
 
 
 class Formatter(argparse.RawDescriptionHelpFormatter, argparse.ArgumentDefaultsHelpFormatter):
@@ -144,11 +149,7 @@ class Uploader(object):
 
 
 def format_rst_changelog(changelog):
-    output = textwrap.dedent("""
-    Changes since last version
-    --------------------------
-    
-    """).splitlines(False)
+    output = CHANGELOG_HEADER.splitlines(False)
     links = {}
     for sha, summary in changelog:
         links[sha] = ".. _{sha}: https://github.com/fiaas/k8s/commit/{sha}".format(sha=sha)

--- a/bin/test_release.py
+++ b/bin/test_release.py
@@ -63,10 +63,10 @@ class TestRepository(object):
         yield repository
 
     @pytest.mark.parametrize("dirty,untracked,result", (
-            (True, True, False),
-            (True, False, False),
-            (False, True, False),
-            (False, False, True)
+        (True, True, False),
+        (True, False, False),
+        (False, True, False),
+        (False, False, True)
     ))
     def test_can_not_release_from_unclean_repo(self, repository, git_repo, dirty, untracked, result):
         git_repo.is_dirty.return_value = dirty
@@ -75,13 +75,13 @@ class TestRepository(object):
         assert repository.ready_for_release() is result
 
     @pytest.mark.parametrize("name,result", (
-            ("v1", True),
-            ("v1.2", True),
-            ("v1.2.3", True),
-            ("v123", True),
-            ("1.2.3", False),
-            ("a.b.c", False),
-            ("v1.a.3", False),
+        ("v1", True),
+        ("v1.2", True),
+        ("v1.2.3", True),
+        ("v123", True),
+        ("1.2.3", False),
+        ("a.b.c", False),
+        ("v1.a.3", False),
     ))
     def test_tag_must_match_version(self, repository, git_repo, name, result):
         git_repo.is_dirty.return_value = False
@@ -95,8 +95,8 @@ class TestRepository(object):
         assert repository.ready_for_release() is result
 
     @pytest.mark.parametrize("current_tag,previous_tag", (
-            ("444444", release.THE_NULL_COMMIT),
-            ("v1.2.3", "v1.2.2")
+        ("444444", release.THE_NULL_COMMIT),
+        ("v1.2.3", "v1.2.2")
     ))
     def test_creates_changelog(self, monkeypatch, repository, git_repo, current_tag, previous_tag):
         monkeypatch.setattr(repository, "_current_tag", current_tag)

--- a/bin/test_release.py
+++ b/bin/test_release.py
@@ -1,0 +1,88 @@
+from __future__ import unicode_literals
+
+import argparse
+
+import mock
+import pytest
+from git import Repo, TagObject, Commit
+
+import release
+
+
+class TestRepository(object):
+    @pytest.fixture
+    def options(self):
+        return argparse.Namespace(directory=".", dry_run=True, force=False)
+
+    @pytest.fixture
+    def git_repo(self):
+        rev_parse_returns = {
+            "heads/master": mock.NonCallableMagicMock(spec=Commit, name="master-commit", hexsha="abcdef"),
+            "v1.2.2": mock.NonCallableMagicMock(spec=TagObject, name="122-tag", tag="v1.2.2"),
+            "v1.2.3": mock.NonCallableMagicMock(spec=TagObject, name="123-tag", tag="v1.2.3")
+        }
+        with mock.patch("release.Repo", spec=Repo, spec_set=True) as mock_repo:
+            mock_repo.git.describe.return_value = "v1.2.3"
+            mock_repo.rev_parse.side_effect = lambda x: rev_parse_returns[x]
+            yield mock_repo
+
+    @pytest.fixture
+    def repository(self, git_repo, options):
+        repository = release.Repository(options)
+        repository.repo = git_repo
+        yield repository
+
+    @pytest.mark.parametrize("dirty,untracked,result", (
+            (True, True, False),
+            (True, False, False),
+            (False, True, False),
+            (False, False, True)
+    ))
+    def test_can_not_release_from_unclean_repo(self, repository, git_repo, dirty, untracked, result):
+        git_repo.is_dirty.return_value = dirty
+        git_repo.untracked_files = ["a"] if untracked else []
+
+        assert repository.ready_for_release() is result
+
+    @pytest.mark.parametrize("name,result", (
+            ("v1", True),
+            ("v1.2", True),
+            ("v1.2.3", True),
+            ("v123", True),
+            ("1.2.3", False),
+            ("a.b.c", False),
+            ("v1.a.3", False),
+    ))
+    def test_tag_must_match_version(self, repository, git_repo, name, result):
+        git_repo.is_dirty.return_value = False
+        git_repo.untracked_files = []
+        git_repo.head.commit = "123"
+        mock_tag = mock.MagicMock()
+        mock_tag.tag = name
+        git_repo.rev_parse.return_value = mock_tag
+        git_repo.rev_parse.side_effect = None
+
+        assert repository.ready_for_release() is result
+
+    def test_creates_changelog(self, repository, git_repo):
+        git_repo.iter_commits.return_value = [
+            mock.NonCallableMagicMock(spec=Commit, hexsha="123456", summary="First commit"),
+            mock.NonCallableMagicMock(spec=Commit, hexsha="abcdef", summary="Second commit")
+        ]
+        changelog = repository.generate_changelog()
+
+        assert len(changelog) == 2
+        assert changelog[0] == "123456 First commit"
+        assert changelog[1] == "abcdef Second commit"
+
+    def test_creates_changelog_since_initial_if_no_tag(self, repository, git_repo):
+        git_repo.iter_commits.return_value = [
+            mock.NonCallableMagicMock(spec=Commit, hexsha="123456", summary="First commit"),
+            mock.NonCallableMagicMock(spec=Commit, hexsha="abcdef", summary="Second commit")
+        ]
+        git_repo.git.describe.return_value = "heads/master"
+        changelog = repository.generate_changelog()
+
+        assert len(changelog) == 2
+        assert changelog[0] == "123456 First commit"
+        assert changelog[1] == "abcdef Second commit"

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8
 
+import subprocess
+
 import os
 from setuptools import setup, find_packages
-
-
-def read(filename):
-    with open(os.path.join(os.path.dirname(__file__), filename)) as f:
-        return f.read()
-
 
 GENERIC_REQ = [
     "six == 1.10.0",
@@ -30,25 +26,55 @@ TESTS_REQ = [
     'pytest >= 3.0'
 ]
 
-setup(
-    name="k8s",
-    author="FINN Team Infrastructure",
-    author_email="FINN-TechteamInfrastruktur@finn.no",
-    version="1.0",
-    packages=find_packages(exclude=("tests",)),
-    zip_safe=True,
-    include_package_data=True,
 
-    # Requirements
-    install_requires=GENERIC_REQ,
-    setup_requires=['pytest-runner', 'wheel', 'setuptools_git >= 0.3'],
-    extras_require={
-        "dev": TESTS_REQ + CODE_QUALITY_REQ,
-        "codacy": ["codacy-coverage"]
-    },
+def _has_tags():
+    """setuptools_git will crash if you ask it to use vcs version without any tags in the repo"""
+    try:
+        subprocess.check_output(["git", "describe"], stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError:
+        return False
+    return True
 
-    # Metadata
-    description="Python client library for the Kubernetes API",
-    long_description=read("README.md"),
-    url="https://github.com/fiaas/k8s",
-)
+
+def _generate_description():
+    description = [_read("README.md")]
+    changelog_file = os.getenv("CHANGELOG_FILE")
+    if changelog_file:
+        description.append(_read(changelog_file))
+    return "\n".join(description)
+
+
+def _read(filename):
+    with open(os.path.join(os.path.dirname(__file__), filename)) as f:
+        return f.read()
+
+
+def main():
+    setup(
+        name="k8s",
+        author="FINN Team Infrastructure",
+        author_email="FINN-TechteamInfrastruktur@finn.no",
+        use_vcs_version=_has_tags(),
+        packages=find_packages(exclude=("tests",)),
+        zip_safe=True,
+        include_package_data=True,
+
+        # Requirements
+        install_requires=GENERIC_REQ,
+        setup_requires=['pytest-runner', 'wheel', 'setuptools_git >= 1.2'],
+        extras_require={
+            "dev": TESTS_REQ + CODE_QUALITY_REQ,
+            "codacy": ["codacy-coverage"],
+            "release": ["gitpython"]
+        },
+
+        # Metadata
+        description="Python client library for the Kubernetes API",
+        long_description=_generate_description(),
+        url="https://github.com/fiaas/k8s",
+        license=_read("LICENSE")
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ def main():
         extras_require={
             "dev": TESTS_REQ + CODE_QUALITY_REQ,
             "codacy": ["codacy-coverage"],
-            "release": ["gitpython"]
+            "release": ["gitpython", "twine"]
         },
 
         # Metadata

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ TESTS_REQ = [
     'pytest-html',
     'pytest-cov',
     'pytest-helpers-namespace',
-    'pytest >= 3.0'
+    'pytest >= 3.0',
+    'gitpython'
 ]
 
 


### PR DESCRIPTION
`bin/release.py` will build source and wheel distributions (aka artifacts), with git changelog as long description.
These artifacts are then uploaded to github as a release named after the current tag, with the same changelog as description.
Then we register a release on pypi, and upload the same artifacts there. PyPI pulls description from the `egg-info` directory, which is created when we create the artifacts.

I have not actually tested these on Github/PyPI yet, I wanted to get feedback on the implementation first.
