### PR TITLE
Making releases work for realz

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,0 @@
-# k8s - Python client library for the Kubernetes API
-[![Build Status](https://semaphoreci.com/api/v1/fiaas/k8s/branches/master/badge.svg)](https://semaphoreci.com/fiaas/k8s)
-[![Codacy Quality Badge](https://api.codacy.com/project/badge/Grade/cb51fc9f95464f22b6084379e88fad77)](https://www.codacy.com/app/mortenlj/k8s?utm_source=github.com&utm_medium=referral&utm_content=fiaas/k8s&utm_campaign=badger)
-[![Codacy Coverage Badge](https://api.codacy.com/project/badge/Coverage/cb51fc9f95464f22b6084379e88fad77)](https://www.codacy.com/app/mortenlj/k8s?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=fiaas/k8s&amp;utm_campaign=Badge_Coverage)

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,12 @@
+k8s - Python client library for the Kubernetes API
+--------------------------------------------------
+
+|Build Status| |Codacy Quality Badge| |Codacy Coverage Badge|
+
+
+.. |Build Status| image:: https://semaphoreci.com/api/v1/fiaas/k8s/branches/master/badge.svg
+    :target: https://semaphoreci.com/fiaas/k8s
+.. |Codacy Quality Badge| image:: https://api.codacy.com/project/badge/Grade/cb51fc9f95464f22b6084379e88fad77
+    :target: https://www.codacy.com/app/mortenlj/k8s?utm_source=github.com&utm_medium=referral&utm_content=fiaas/k8s&utm_campaign=badger
+.. |Codacy Coverage Badge| image:: https://api.codacy.com/project/badge/Coverage/cb51fc9f95464f22b6084379e88fad77
+    :target: https://www.codacy.com/app/mortenlj/k8s?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=fiaas/k8s&amp;utm_campaign=Badge_Coverage

--- a/bin/release.py
+++ b/bin/release.py
@@ -119,7 +119,6 @@ class Uploader(object):
         self.version = version
         self.changelog = changelog
         self.artifacts = artifacts
-        self._changelog = format_rst_changelog(self.changelog)
 
     def _call(self, *args, **kwargs):
         msg = kwargs.pop("msg", "")
@@ -138,11 +137,18 @@ class Uploader(object):
         """Create release in github.com, and upload artifacts and changelog"""
         gh_path = os.getenv("GITHUB_RELEASE")
         if gh_path:
-            self._call(gh_path, "release", "--tag", self.version, "--description", self._changelog,
+            self._call(gh_path, "release",
+                       "--repo", "k8s",
+                       "--tag", self.version,
+                       "--description", format_gh_changelog(self.changelog),
                        msg="Failed to create release on Github")
             for artifact in self.artifacts:
                 name = os.path.basename(artifact)
-                self._call(gh_path, "upload", "--tag", self.version, "--name", name, "--file", artifact,
+                self._call(gh_path, "upload",
+                           "--repo", "k8s",
+                           "--tag", self.version,
+                           "--name", name,
+                           "--file", artifact,
                            msg="Failed to upload artifact {} to Github".format(name))
 
     def pypi_release(self):
@@ -166,6 +172,16 @@ def format_rst_changelog(changelog):
     return "\n".join(output)
 
 
+def format_gh_changelog(changelog):
+    output = CHANGELOG_HEADER.splitlines(False)
+    links = {}
+    for sha, summary in changelog:
+        output.append("* {sha}: {summary}".format(sha=sha, summary=summary))
+    output.append("")
+    output.extend(links.values())
+    return "\n".join(output)
+
+
 def create_artifacts(changelog):
     """List all artifacts for uploads
 
@@ -174,8 +190,12 @@ def create_artifacts(changelog):
     fd, name = tempfile.mkstemp(prefix="changelog", suffix=".rst", text=True)
     with os.fdopen(fd, "w") as fobj:
         fobj.write(format_rst_changelog(changelog).encode("utf-8"))
-    subprocess.check_call([sys.executable, "setup.py", "sdist", "bdist_wheel", "--universal"],
-                          env={"CHANGELOG_FILE": name})
+    subprocess.check_call([
+        sys.executable, "setup.py",
+        "egg_info", "--tag-build=",
+        "sdist",
+        "bdist_wheel", "--universal"
+    ], env={"CHANGELOG_FILE": name})
     os.unlink(name)
     return [os.path.abspath(os.path.join("dist", fname)) for fname in os.listdir("dist")]
 

--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,18 @@ TESTS_REQ = [
 
 
 def _generate_description():
-    description = [_read("README.md")]
+    description = [_read("README.rst")]
     changelog_file = os.getenv("CHANGELOG_FILE")
     if changelog_file:
         description.append(_read(changelog_file))
     return "\n".join(description)
+
+
+def _get_license_name():
+    with open(os.path.join(os.path.dirname(__file__), "LICENSE")) as f:
+        for line in f:
+            if line.strip():
+                return line.strip()
 
 
 def _read(filename):
@@ -62,7 +69,7 @@ def main():
         description="Python client library for the Kubernetes API",
         long_description=_generate_description(),
         url="https://github.com/fiaas/k8s",
-        license=_read("LICENSE")
+        license=_get_license_name()
     )
 
 


### PR DESCRIPTION
Various fixes to make releasing work as we want.

The release script will now build tarball and wheel based on the tag it's on, then create a changelog by dumping the log between this tag and the previous one.

The tarball and wheel are uploaded to Github release, with the changelog attached as a release description, and to PyPI with the README and changelog concatenated to form a package description.

The changelog has links to commits, and in some cases to Github PR. The first version released will have some links to PRs that fail because they are in reality to PRs that only exists at the old location of the repo. As development moves on, this won't be a problem anymore.
