### PR TITLE
Add auto-generated CRD docs

### DIFF
--- a/docs/source/modules/k8s.models.custom_resource_definition.rst
+++ b/docs/source/modules/k8s.models.custom_resource_definition.rst
@@ -1,0 +1,7 @@
+k8s\.models\.custom\_resource\_definition module
+================================================
+
+.. automodule:: k8s.models.custom_resource_definition
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/modules/k8s.models.rst
+++ b/docs/source/modules/k8s.models.rst
@@ -14,6 +14,7 @@ Submodules
    k8s.models.autoscaler
    k8s.models.common
    k8s.models.configmap
+   k8s.models.custom_resource_definition
    k8s.models.deployment
    k8s.models.ingress
    k8s.models.pod


### PR DESCRIPTION
When generating docs, these files are auto-generated. Since we have commited all the others, I guess this one should be commited too.