### PR TITLE
Watcher

### DIFF
--- a/docs/source/modules/k8s.rst
+++ b/docs/source/modules/k8s.rst
@@ -22,4 +22,5 @@ Submodules
    k8s.client
    k8s.config
    k8s.fields
+   k8s.watcher
 

--- a/docs/source/modules/k8s.watcher.rst
+++ b/docs/source/modules/k8s.watcher.rst
@@ -1,0 +1,7 @@
+k8s\.watcher module
+===================
+
+.. automodule:: k8s.watcher
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/k8s/watcher.py
+++ b/k8s/watcher.py
@@ -9,11 +9,27 @@ DEFAULT_CAPACITY = 1000
 
 
 class Watcher(object):
+    """Higher-level interface to watch for changes in objects
+
+    The low-level :py:meth:`~.watch_list` method will stop when the API-server drops the connection.
+    When reconnecting, the API-server will send a list of :py:const:`~k8s.base.WatchEvent.ADDED`
+    events for all objects, even if they have been seen before.
+
+    The Watcher will hide this complexity for you, and make sure to reconnect when the
+    connection drops, and skip events that have already been seen.
+
+    :param Model model: The model class to watch
+    :param int capacity: How many seen objects to keep track of
+    """
     def __init__(self, model, capacity=DEFAULT_CAPACITY):
         self._seen = cachetools.LRUCache(capacity)
         self._model = model
 
     def watch(self):
+        """Watch for events
+
+        :return: a generator that yields :py:class:`~.WatchEvent` objects not seen before
+        """
         while True:
             for event in self._model.watch_list():
                 o = event.object

--- a/k8s/watcher.py
+++ b/k8s/watcher.py
@@ -17,8 +17,8 @@ class Watcher(object):
         while True:
             for event in self._model.watch_list():
                 o = event.object
-                key = (o.metadata.name, o.metadata.resourceVersion)
-                if key in self._seen and event.type != WatchEvent.DELETED:
+                key = (o.metadata.name, o.metadata.namespace)
+                if self._seen.get(key) == o.metadata.resourceVersion and event.type != WatchEvent.DELETED:
                     continue
-                self._seen[key] = True
+                self._seen[key] = o.metadata.resourceVersion
                 yield event

--- a/k8s/watcher.py
+++ b/k8s/watcher.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import cachetools
+
+from k8s.base import WatchEvent
+
+DEFAULT_CAPACITY = 1000
+
+
+class Watcher(object):
+    def __init__(self, model, capacity=DEFAULT_CAPACITY):
+        self._seen = cachetools.LRUCache(capacity)
+        self._model = model
+
+    def watch(self):
+        while True:
+            for event in self._model.watch_list():
+                o = event.object
+                key = (o.metadata.name, o.metadata.resourceVersion)
+                if key in self._seen and event.type != WatchEvent.DELETED:
+                    continue
+                self._seen[key] = True
+                yield event

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ GENERIC_REQ = [
     "six == 1.10.0",
     "requests == 2.13.0",
     "pyrfc3339 == 1.0",
+    "cachetools == 2.0.1",
 ]
 
 CODE_QUALITY_REQ = [

--- a/tests/k8s/test_watcher.py
+++ b/tests/k8s/test_watcher.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+import mock
+import pytest
+import six
+
+from k8s.base import Model, Field, WatchEvent
+from k8s.models.common import ObjectMeta
+from k8s.watcher import Watcher
+
+# Just to make things shorter
+ADDED = WatchEvent.ADDED
+MODIFIED = WatchEvent.MODIFIED
+DELETED = WatchEvent.DELETED
+
+
+@pytest.mark.usefixtures("k8s_config", "logger")
+class TestWatcher(object):
+    @pytest.fixture
+    def api_watch_list(self):
+        with mock.patch('k8s.base.ApiMixIn.watch_list') as m:
+            yield m
+
+    def test_multiple_events(self, api_watch_list):
+        number_of_events = 20
+        events = [_event(i, ADDED, 1) for i in range(number_of_events)]
+        api_watch_list.side_effect = [events]
+        gen = Watcher(WatchListExample).watch()
+
+        for i in range(number_of_events):
+            _assert_event(next(gen), i, ADDED, 1)
+        with pytest.raises(StopIteration):
+            next(gen)
+
+    def test_handle_reconnect(self, api_watch_list):
+        events = [_event(0, ADDED, 1)]
+        api_watch_list.side_effect = [events, events]
+        gen = Watcher(WatchListExample).watch()
+
+        _assert_event(next(gen), 0, ADDED, 1)
+        with pytest.raises(StopIteration):
+            next(gen)
+
+    def test_handle_changes(self, api_watch_list):
+        events = [_event(0, ADDED, 1), _event(0, MODIFIED, 2)]
+        api_watch_list.side_effect = [events]
+        gen = Watcher(WatchListExample).watch()
+
+        _assert_event(next(gen), 0, ADDED, 1)
+        _assert_event(next(gen), 0, MODIFIED, 2)
+
+        with pytest.raises(StopIteration):
+            next(gen)
+
+    def test_complicated(self, api_watch_list):
+        first = [_event(0, ADDED, 1), _event(1, ADDED, 1), _event(2, ADDED, 1)]
+        second = [_event(0, ADDED, 1), _event(1, ADDED, 2), _event(2, ADDED, 1), _event(0, MODIFIED, 2)]
+        third = [_event(0, ADDED, 2), _event(1, DELETED, 2), _event(2, ADDED, 1), _event(2, MODIFIED, 2)]
+        api_watch_list.side_effect = [first, second, third]
+        gen = Watcher(WatchListExample).watch()
+
+        # First batch
+        _assert_event(next(gen), 0, ADDED, 1)
+        _assert_event(next(gen), 1, ADDED, 1)
+        _assert_event(next(gen), 2, ADDED, 1)
+
+        # Second batch
+        _assert_event(next(gen), 1, ADDED, 2)
+        _assert_event(next(gen), 0, MODIFIED, 2)
+
+        # Third batch
+        _assert_event(next(gen), 1, DELETED, 2)
+        _assert_event(next(gen), 2, MODIFIED, 2)
+
+        with pytest.raises(StopIteration):
+            next(gen)
+
+
+def _event(id, event_type, rv):
+    metadict = {"name": "name{}".format(id), "resourceVersion": rv}
+    metadata = ObjectMeta.from_dict(metadict)
+    wle = WatchListExample(metadata=metadata, value=(id * 100) + rv)
+    return mock.NonCallableMagicMock(type=event_type, object=wle)
+
+
+def _assert_event(event, id, event_type, rv):
+    assert event.type == event_type
+    o = event.object
+    assert o.kind == "Example"
+    assert o.metadata.name == "name{}".format(id)
+    assert o.value == (id * 100) + rv
+
+
+class WatchListExample(Model):
+    class Meta:
+        url_template = '/example'
+        watch_list_url = '/watch/example'
+
+    apiVersion = Field(six.text_type, "example.com/v1")
+    kind = Field(six.text_type, "Example")
+    metadata = Field(ObjectMeta)
+    value = Field(int)
+
+
+class SentinelException(Exception):
+    pass


### PR DESCRIPTION
By creating a watcher, you get a high-level event generator, which hides some of the complexities of watching objects in the kubernetes API.

I will need to add support for watching just a single namespace, when #29 is merged, but otherwise I think this is ready to go.
