### PR TITLE
Try to not leak sensitive headers when logging HTTP errors

### DIFF
--- a/k8s/client.py
+++ b/k8s/client.py
@@ -9,9 +9,37 @@ from requests import RequestException
 
 from . import config
 
-DEFAULT_TIMEOUT_SECONDS = 10
 LOG = logging.getLogger(__name__)
 LOG.addHandler(logging.NullHandler())
+
+DEFAULT_TIMEOUT_SECONDS = 10
+SENSITIVE_HEADERS = {
+    # Wordlist lifted from https://github.com/google/har-sanitizer/blob/master/harsanitizer/static/wordlist.json
+    "state",
+    "shdf",
+    "usg",
+    "password",
+    "email",
+    "code",
+    "code_verifier",
+    "client_secret",
+    "client_id",
+    "token",
+    "access_token",
+    "authenticity_token",
+    "id_token",
+    "appid",
+    "challenge",
+    "facetid",
+    "assertion",
+    "fcparams",
+    "serverdata",
+    "authorization",
+    "auth",
+    "x-client-data",
+    "samlrequest",
+    "samlresponse"
+}
 
 
 class K8sClientException(RequestException):
@@ -125,4 +153,6 @@ class Client(object):
     @staticmethod
     def _add_headers(message, headers, prefix):
         for key, value in headers.items():
+            if key.lower() in SENSITIVE_HEADERS:
+                value = "#REDACTED#"
             message.append("{} {}: {}".format(prefix, key, value))

--- a/tests/k8s/test_client.py
+++ b/tests/k8s/test_client.py
@@ -4,9 +4,9 @@
 import mock
 import pytest
 
-from k8s.client import Client, DEFAULT_TIMEOUT_SECONDS
 from k8s import config
 from k8s.base import Model, Field
+from k8s.client import Client, DEFAULT_TIMEOUT_SECONDS
 
 
 @pytest.mark.usefixtures("k8s_config")
@@ -95,6 +95,17 @@ class TestClient(object):
         session.request.assert_called_once_with(
             "GET", _absolute_url("/watch/example"), json=None, timeout=None, stream=True
         )
+
+    @pytest.mark.parametrize("key", (
+            "client_id",
+            "authorization"
+    ))
+    def test_redacts_sensitive_headers(self, key):
+        message = []
+        sensitive_value = "super sensitive data that should not be exposed"
+        Client._add_headers(message, {key: sensitive_value}, "")
+        text = "".join(message)
+        assert sensitive_value not in text
 
 
 def _absolute_url(url):


### PR DESCRIPTION
I realized that when we get an error from the k8s API, we log as much information as possible (on DEBUG), in order to aid troubleshooting. We also add it the information to the exception before raising it, so if the user code logs the full exception, the entire request/response is logged.

This includes authorization headers, which is probably bad.

This code strips the values of known sensitive headers before attaching to logs/exception. Some of these headers will never be used by this client library, but it seems prudent to err on the side of caution.
