### PR TITLE
Pin pytest to 3.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ TESTS_REQ = [
     'pytest-html',
     'pytest-cov',
     'pytest-helpers-namespace',
-    'pytest >= 3.0',
+    'pytest==3.3.2',
     'gitpython',
 ]
 


### PR DESCRIPTION
pytest 3.4.0 does not work with tox 2.7 and not with the current version (3.0.0rc1) of tox either