### PR TITLE
Handle Field(dict) similar to other types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 *,cover

--- a/k8s/base.py
+++ b/k8s/base.py
@@ -184,9 +184,10 @@ class Model(six.with_metaclass(MetaModel)):
                 d[_api_name(field.name)] = value
         return d
 
-    def update(self, other):
+    def merge(self, other):
         for field in self._meta.fields:
             setattr(self, field.name, getattr(other, field.name))
+    update = merge  # For backwards compatibility
 
     def update_from_dict(self, d):
         for field in self._meta.fields:

--- a/k8s/fields.py
+++ b/k8s/fields.py
@@ -44,7 +44,7 @@ class Field(object):
             return
         if new_value is not None:
             try:
-                current_value.update(new_value)
+                current_value.merge(new_value)
                 return
             except AttributeError:
                 pass


### PR DESCRIPTION
All other types are replaced when a new value is provided, but for dict
fields we merged the existing value with the new one.
This change makes Field(dict) behave the same as other types, replacing
the dictionary instead of merging.