### PR TITLE
Set a timeout for watch connections

### DIFF
--- a/k8s/base.py
+++ b/k8s/base.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 
 import six
 
+from . import config
 from .client import Client, NotFound
 from .fields import Field
 
@@ -103,7 +104,7 @@ class ApiMixIn(object):
             if not url:
                 raise NotImplementedError("Cannot watch_list, no watch_list_url defined on class {}".format(cls))
 
-        resp = cls._client.get(url, stream=True, timeout=None)
+        resp = cls._client.get(url, stream=True, timeout=config.stream_timeout)
         for line in resp.iter_lines(chunk_size=None):
             if line:
                 try:

--- a/k8s/config.py
+++ b/k8s/config.py
@@ -3,9 +3,19 @@
 
 """Singleton configuration for k8s client"""
 
+#: API server URL
 api_server = "https://kubernetes.default.svc.cluster.local"
+#: API token
 api_token = ""
+#: API certificate
 cert = None
+#: Should the client verify the servers SSL certificates?
 verify_ssl = True
+#: Enable debugging
 debug = False
+#: Default timeout for most operations
 timeout = 20
+#: Default timeout for streaming operations
+stream_timeout = 3600
+#: Default size of Watcher cache
+watcher_cache_size = 1000

--- a/k8s/watcher.py
+++ b/k8s/watcher.py
@@ -3,7 +3,7 @@
 
 import cachetools
 
-from k8s.base import WatchEvent
+from .base import WatchEvent
 
 DEFAULT_CAPACITY = 1000
 
@@ -28,8 +28,8 @@ class Watcher(object):
     def watch(self, namespace=None):
         """Watch for events
 
-        :param str namespace: the namespace to watch for events in. The default (None) results in watching for events
-        in all namespaces.
+        :param str namespace: the namespace to watch for events in. The default (None) results in
+            watching for events in all namespaces.
         :return: a generator that yields :py:class:`~.WatchEvent` objects not seen before
         """
         while True:

--- a/tests/k8s/test_client.py
+++ b/tests/k8s/test_client.py
@@ -97,13 +97,13 @@ class TestClient(object):
     def test_watch_list(self, session):
         list(WatchListExample.watch_list())
         session.request.assert_called_once_with(
-            "GET", _absolute_url("/watch/example"), json=None, timeout=None, stream=True
+            "GET", _absolute_url("/watch/example"), json=None, timeout=config.stream_timeout, stream=True
         )
 
     def test_watch_list_with_namespace(self, session):
         list(WatchListExample.watch_list(namespace="explicitly-set"))
         session.request.assert_called_once_with(
-            "GET", _absolute_url("/watch/explicitly-set/example"), json=None, timeout=None, stream=True
+            "GET", _absolute_url("/watch/explicitly-set/example"), json=None, timeout=config.stream_timeout, stream=True
         )
 
     def test_list_without_namespace_should_raise_exception_when_list_url_is_not_set_on_metaclass(self, session):


### PR DESCRIPTION
In Amazon EKS, we experience the API server connection silently failing,
so we add a timeout to force a reconnect after a period of inactivity.