### PR TITLE
Ignore .pip_cache, so semaphore builds can be published

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pip_cache
 .pytest_cache
 nosetests.xml
 coverage.xml


### PR DESCRIPTION
Once this change is merged, I'm going to release version 0.12.0 of the library.