### PR TITLE
Remove the build badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,8 @@
 k8s - Python client library for the Kubernetes API
 --------------------------------------------------
 
-|Build Status| |Codacy Quality Badge| |Codacy Coverage Badge|
+|Codacy Quality Badge| |Codacy Coverage Badge|
 
-.. |Build Status| image:: https://semaphoreci.com/api/v1/fiaas/k8s/branches/master/badge.svg
-    :target: https://semaphoreci.com/fiaas/k8s
 .. |Codacy Quality Badge| image:: https://api.codacy.com/project/badge/Grade/cb51fc9f95464f22b6084379e88fad77
     :target: https://www.codacy.com/app/mortenlj/k8s?utm_source=github.com&utm_medium=referral&utm_content=fiaas/k8s&utm_campaign=badger
 .. |Codacy Coverage Badge| image:: https://api.codacy.com/project/badge/Coverage/cb51fc9f95464f22b6084379e88fad77


### PR DESCRIPTION
Semaphore 2.0 doesn't support badges (yet), and I have just deleted the project on Semaphore Classic, so the badge needs to go.
Will add a new badge once 2.0 supports it.

Final steps needed to convert to Semaphore 2.0 builds.

Fixes #59