### PR TITLE
Update endpoints for Deployment

### DIFF
--- a/k8s/models/deployment.py
+++ b/k8s/models/deployment.py
@@ -59,8 +59,8 @@ class DeploymentStatus(Model):
 
 class Deployment(Model):
     class Meta:
-        list_url = "/apis/extensions/v1beta1/deployments"
-        url_template = "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}"
+        list_url = "/apis/apps/v1/deployments"
+        url_template = "/apis/apps/v1/namespaces/{namespace}/deployments/{name}"
 
     metadata = Field(ObjectMeta)
     spec = Field(DeploymentSpec)

--- a/tests/k8s/test_deployer.py
+++ b/tests/k8s/test_deployer.py
@@ -182,4 +182,4 @@ def _create_mock_response():
 
 
 def _uri(namespace, name=""):
-    return "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}".format(name=name, namespace=namespace)
+    return "/apis/apps/v1/namespaces/{namespace}/deployments/{name}".format(name=name, namespace=namespace)


### PR DESCRIPTION
Change from the deprecated extensions/v1beta1/Deployment endpoint,
which will be removed by default in kubernetes 1.16,
to apps/v1/Deployment, which is available since kubernetes 1.9

Relates to fiaas/fiaas-deploy-daemon#39