### PR TITLE
Add support for deleting multiple objects

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -150,6 +150,13 @@ objects, you need to pass a `DeleteOptions` object with a `propagationPolicy` to
   }
   >>> Deployment.delete('nginx', body=delete_options)
 
+To delete multiple resources in a single call, use the `delete_list` function. You can use label-selectors to
+filter what will be deleted, and you can pass `DeleteOptions` as explained above::
+
+  >>> delete_options = DeleteOptions(propagationPolicy='Foreground')
+  >>> label_selectors = {"foo": Equality("bar"), "dog": Inequality("cat")}
+  >>> Ingress.delete_list(labels=label_selectors, delete_options=delete_options)
+
 
 Watch resources
 ---------------

--- a/k8s/base.py
+++ b/k8s/base.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -185,6 +185,16 @@ class ApiMixIn(object):
         """Delete the named resource"""
         url = cls._build_url(name=name, namespace=namespace)
         cls._client.delete(url, **kwargs)
+
+    @classmethod
+    def delete_list(cls, namespace="default", labels=None, delete_options=None, **kwargs):
+        selector = ",".join("{}{}".format(k, v if isinstance(v, LabelSelector) else Equality(v))
+                            for k, v in sorted(labels.items(), key=lambda kv: kv[0]))
+        url = cls._build_url(name="", namespace=namespace)
+        if delete_options:
+            delete_options = delete_options.as_dict()
+
+        cls._client.delete(url, body=delete_options, params={"labelSelector": selector}, **kwargs)
 
     def save(self):
         """Save to API server, either update if existing, or create if new"""

--- a/k8s/models/common.py
+++ b/k8s/models/common.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,3 +49,17 @@ class ObjectMeta(Model):
     resourceVersion = ReadOnlyField(six.text_type)
     selfLink = ReadOnlyField(six.text_type)
     uid = ReadOnlyField(six.text_type)
+
+
+class Preconditions(Model):
+    resourceVersion = Field(six.text_type)
+    uid = Field(six.text_type)
+
+
+class DeleteOptions(Model):
+    apiVersion = Field(six.text_type)
+    dryRun = ListField(six.text_type)
+    gracePeriodSeconds = Field(int)
+    kind = Field(six.text_type)
+    preconditions = Field(Preconditions)
+    propagationPolicy = Field(six.text_type)


### PR DESCRIPTION
Deleting objects using label-selectors can be useful; this change
adds a new method to models allowing this to be done.