### PR TITLE
Pin version of gitdb2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,6 +39,7 @@ TESTS_REQ = [
     "pytest-cov==2.7.1",
     "pytest-helpers-namespace==2019.1.8",
     'pytest==3.10.1',
+    'gitdb2==2.0.6',
     "GitPython==2.1.14",
 ]
 


### PR DESCRIPTION
Newer versions of gitdb2 have dependencies on gitdb versions that
aren't available for py27