### PR TITLE
Clean up left-overs after changing to using publish

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,6 @@ TESTS_REQ = [
     'pytest==3.10.1',
 ]
 
-# These are not direct dependencies, but we need to lock down their versions here
-EXTRA_REQ = [
-]
-
 
 def _generate_description():
     description = [_read("README.rst")]
@@ -80,7 +76,7 @@ def main():
         install_requires=GENERIC_REQ,
         setup_requires=['pytest-runner', 'wheel', 'setuptools_scm'],
         extras_require={
-            "dev": TESTS_REQ + CODE_QUALITY_REQ + EXTRA_REQ,
+            "dev": TESTS_REQ + CODE_QUALITY_REQ,
             "codacy": ["codacy-coverage"],
             "docs": ["Sphinx>=1.6.3"]
         },

--- a/setup.py
+++ b/setup.py
@@ -39,14 +39,10 @@ TESTS_REQ = [
     "pytest-cov==2.7.1",
     "pytest-helpers-namespace==2019.1.8",
     'pytest==3.10.1',
-    'gitdb2==2.0.6',
-    "GitPython==2.1.14",
 ]
 
 # These are not direct dependencies, but we need to lock down their versions here
 EXTRA_REQ = [
-    # "pluggy==0.12.0",
-    # "prospector==1.9.0",
 ]
 
 
@@ -86,7 +82,6 @@ def main():
         extras_require={
             "dev": TESTS_REQ + CODE_QUALITY_REQ + EXTRA_REQ,
             "codacy": ["codacy-coverage"],
-            "release": ["gitpython", "twine"],
             "docs": ["Sphinx>=1.6.3"]
         },
         tests_require=TESTS_REQ,


### PR DESCRIPTION
These dependencies seem to just be left-overs after the change to use publish. All tests ran ok on my machine after removing, and I can't think of a place where it would be needed.

See also #77.