### PR TITLE
Remove py35 as environment

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,12 +1,12 @@
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,7 +40,7 @@ blocks:
             - tox
           matrix:
             - env_var: TOXENV
-              values: ["py27", "py35", "py36", "py37"]
+              values: ["py27", "py36", "py37"]
         - name: Gather coverage data
           commands:
             - tox -e coverage


### PR DESCRIPTION
Semaphore doesn't have this version available, so the tests are always
being skipped.