### PR TITLE
Support repeated keys in labelSelectors

### DIFF
--- a/tests/k8s/test_base.py
+++ b/tests/k8s/test_base.py
@@ -69,6 +69,17 @@ class TestFind(object):
         Example.find(labels={"my_key": value})
         client.get.assert_called_once_with("/example", params={"labelSelector": selector})
 
+    def test_repeated_keys_in_label_selector(self, client):
+        labels = [
+            ("foo", Inequality("bar")),
+            ("foo", Exists())
+        ]
+        Example.find(labels=labels)
+
+        expected_selector = "foo!=bar,foo"
+
+        client.get.assert_called_once_with("/example", params={"labelSelector": expected_selector})
+
 
 class TestDeleteList(object):
 


### PR DESCRIPTION
To express the condition "foo!=bar,foo" (foo doesn't equal bar, but
does exist) isn't possible if we restrict the input to a dict.
This change means it can now either be a dict, or a list of
(key, value) tuples; in the case of a dict, it's converted to
such a list before it's processed.