### PR TITLE
Disable the N815 rule

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -14,6 +14,8 @@ ignore-paths:
 pep8:
   options:
     max-line-length: 120
+  disable:
+    - N815 # mixedCase variable in class scope
 
 mccabe:
   max-complexity: 10


### PR DESCRIPTION
As seen elsewhere in our repos, the rule trips on all our k8s models,
so disabling it for the entire project makes sense.

I will merge this without approval, as it is such a trivial change and it makes it easier to resolve many of the issues in #87 by rebasing on master.
