### PR TITLE
Updated Watcher to use Bookmark events and restart watch from last observed event

### DIFF
--- a/k8s/base.py
+++ b/k8s/base.py
@@ -123,9 +123,13 @@ class ApiMixIn(object):
         url_query_params = parse_qs(query)
 
         url_query_params["watch"] = [1]
-        url_query_params["resourceVersion"] = [start_at_resource_version] if start_at_resource_version != None else []
         url_query_params["allowWatchBookmarks"] = ["true"]
-        
+
+        if start_at_resource_version is None:
+            url_query_params["resourceVersion"] = []
+        else:
+            url_query_params["resourceVersion"] = [start_at_resource_version]
+
         query = urlencode(url_query_params, doseq=True)
         return urlunsplit((scheme, netloc, path, query, fragment))
 

--- a/k8s/watcher.py
+++ b/k8s/watcher.py
@@ -15,9 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import cachetools
-
 from .base import WatchEvent
 
 DEFAULT_CAPACITY = 1000
@@ -56,7 +53,6 @@ class Watcher(object):
                 namespace=namespace, 
                 start_at_resource_version=last_seen_version
             ):
-                o = event.object
                 last_seen_version = event.resourceVersion
                 if event.type != WatchEvent.BOOKMARK:
                     yield event

--- a/tests/k8s/test_base.py
+++ b/tests/k8s/test_base.py
@@ -31,19 +31,27 @@ class Example(Model):
 
 
 class TestWatchEvent(object):
+
+    common_object = {"value": 42, "metadata": {"resourceVersion":1}}
+
     def test_watch_event_added(self):
-        watch_event = WatchEvent({"type": "ADDED", "object": {"value": 42, "metadata": {"resourceVersion":1}}}, Example)
+        watch_event = WatchEvent({"type": "ADDED", "object": self.common_object}, Example)
         assert watch_event.type == WatchEvent.ADDED
         assert watch_event.object == Example(value=42)
 
     def test_watch_event_modified(self):
-        watch_event = WatchEvent({"type": "MODIFIED", "object": {"value": 42, "metadata": {"resourceVersion":1}}}, Example)
+        watch_event = WatchEvent({"type": "MODIFIED", "object": self.common_object}, Example)
         assert watch_event.type == WatchEvent.MODIFIED
         assert watch_event.object == Example(value=42)
 
     def test_watch_event_deleted(self):
-        watch_event = WatchEvent({"type": "DELETED","object": {"value": 42, "metadata": {"resourceVersion":1}}}, Example)
+        watch_event = WatchEvent({"type": "DELETED", "object": self.common_object}, Example)
         assert watch_event.type == WatchEvent.DELETED
+        assert watch_event.object == Example(value=42)
+
+    def test_watch_event_bookmark(self):
+        watch_event = WatchEvent({"type": "BOOKMARK", "object": self.common_object}, Example)
+        assert watch_event.type == WatchEvent.BOOKMARK
         assert watch_event.object == Example(value=42)
 
 

--- a/tests/k8s/test_base.py
+++ b/tests/k8s/test_base.py
@@ -32,7 +32,7 @@ class Example(Model):
 
 class TestWatchEvent(object):
 
-    common_object = {"value": 42, "metadata": {"resourceVersion":1}}
+    common_object = {"value": 42, "metadata": {"resourceVersion": 1}}
 
     def test_watch_event_added(self):
         watch_event = WatchEvent({"type": "ADDED", "object": self.common_object}, Example)

--- a/tests/k8s/test_base.py
+++ b/tests/k8s/test_base.py
@@ -32,17 +32,17 @@ class Example(Model):
 
 class TestWatchEvent(object):
     def test_watch_event_added(self):
-        watch_event = WatchEvent({"type": "ADDED", "object": {"value": 42}}, Example)
+        watch_event = WatchEvent({"type": "ADDED", "object": {"value": 42, "metadata": {"resourceVersion":1}}}, Example)
         assert watch_event.type == WatchEvent.ADDED
         assert watch_event.object == Example(value=42)
 
     def test_watch_event_modified(self):
-        watch_event = WatchEvent({"type": "MODIFIED", "object": {"value": 42}}, Example)
+        watch_event = WatchEvent({"type": "MODIFIED", "object": {"value": 42, "metadata": {"resourceVersion":1}}}, Example)
         assert watch_event.type == WatchEvent.MODIFIED
         assert watch_event.object == Example(value=42)
 
     def test_watch_event_deleted(self):
-        watch_event = WatchEvent({"type": "DELETED", "object": {"value": 42}}, Example)
+        watch_event = WatchEvent({"type": "DELETED","object": {"value": 42, "metadata": {"resourceVersion":1}}}, Example)
         assert watch_event.type == WatchEvent.DELETED
         assert watch_event.object == Example(value=42)
 

--- a/tests/k8s/test_client.py
+++ b/tests/k8s/test_client.py
@@ -122,7 +122,8 @@ class TestClient(object):
     def test_watch_list(self, session):
         list(WatchListExample.watch_list())
         session.request.assert_called_once_with(
-            "GET", _absolute_url("/watch/example?watch=1&allowWatchBookmarks=true"), json=None, timeout=config.stream_timeout, stream=True
+            "GET", _absolute_url("/watch/example?watch=1&allowWatchBookmarks=true"), 
+            json=None, timeout=config.stream_timeout, stream=True
         )
 
     def test_watch_list_with_namespace(self, session):
@@ -135,7 +136,7 @@ class TestClient(object):
     def test_watch_list_starting_from_resource_version(self, session):
         list(WatchListExample.watch_list(start_at_resource_version=10))
         session.request.assert_called_once_with(
-            "GET", _absolute_url("/watch/example?watch=1&resourceVersion=10&allowWatchBookmarks=true"), 
+            "GET", _absolute_url("/watch/example?watch=1&allowWatchBookmarks=true&resourceVersion=10"), 
             json=None, timeout=config.stream_timeout, stream=True
         )
 

--- a/tests/k8s/test_client.py
+++ b/tests/k8s/test_client.py
@@ -122,13 +122,21 @@ class TestClient(object):
     def test_watch_list(self, session):
         list(WatchListExample.watch_list())
         session.request.assert_called_once_with(
-            "GET", _absolute_url("/watch/example"), json=None, timeout=config.stream_timeout, stream=True
+            "GET", _absolute_url("/watch/example?watch=1&allowWatchBookmarks=true"), json=None, timeout=config.stream_timeout, stream=True
         )
 
     def test_watch_list_with_namespace(self, session):
         list(WatchListExample.watch_list(namespace="explicitly-set"))
         session.request.assert_called_once_with(
-            "GET", _absolute_url("/watch/explicitly-set/example"), json=None, timeout=config.stream_timeout, stream=True
+            "GET", _absolute_url("/watch/explicitly-set/example?watch=1&allowWatchBookmarks=true"), 
+            json=None, timeout=config.stream_timeout, stream=True
+        )
+
+    def test_watch_list_starting_from_resource_version(self, session):
+        list(WatchListExample.watch_list(start_at_resource_version=10))
+        session.request.assert_called_once_with(
+            "GET", _absolute_url("/watch/example?watch=1&resourceVersion=10&allowWatchBookmarks=true"), 
+            json=None, timeout=config.stream_timeout, stream=True
         )
 
     def test_list_without_namespace_should_raise_exception_when_list_url_is_not_set_on_metaclass(self, session):

--- a/tests/k8s/test_watcher.py
+++ b/tests/k8s/test_watcher.py
@@ -28,6 +28,7 @@ from k8s.watcher import Watcher
 ADDED = WatchEvent.ADDED
 MODIFIED = WatchEvent.MODIFIED
 DELETED = WatchEvent.DELETED
+BOOKMARK = WatchEvent.BOOKMARK
 
 
 @pytest.mark.usefixtures("k8s_config", "logger")
@@ -49,7 +50,7 @@ class TestWatcher(object):
         watcher._run_forever = False
         assert list(gen) == []
 
-        api_watch_list.assert_called_with(namespace=None)
+        api_watch_list.assert_called_with(namespace=None, start_at_resource_version=None)
 
     def test_handle_reconnect(self, api_watch_list):
         events = [_event(0, ADDED, 1)]
@@ -75,9 +76,9 @@ class TestWatcher(object):
 
     def test_complicated(self, api_watch_list):
         first = [_event(0, ADDED, 1), _event(1, ADDED, 1), _event(2, ADDED, 1)]
-        second = [_event(0, ADDED, 1), _event(1, ADDED, 2), _event(2, ADDED, 1), _event(0, MODIFIED, 2)]
-        third = [_event(0, ADDED, 2), _event(1, DELETED, 2), _event(2, ADDED, 1), _event(2, MODIFIED, 2)]
-        fourth = [_event(0, ADDED, 2), _event(0, ADDED, 1, "other"), _event(0, MODIFIED, 2, "other")]
+        second = [_event(3, ADDED, 1), _event(4, ADDED, 2), _event(5, ADDED, 1), _event(6, MODIFIED, 2)]
+        third = [_event(7, ADDED, 2), _event(8, DELETED, 2), _event(9, ADDED, 1), _event(20, BOOKMARK, 2)]
+        fourth = [_event(25, ADDED, 2), _event(26, ADDED, 1), _event(27, MODIFIED, 2)]
         api_watch_list.side_effect = [first, second, third, fourth]
         watcher = Watcher(WatchListExample)
         gen = watcher.watch()
@@ -88,16 +89,20 @@ class TestWatcher(object):
         _assert_event(next(gen), 2, ADDED, 1)
 
         # Second batch
-        _assert_event(next(gen), 1, ADDED, 2)
-        _assert_event(next(gen), 0, MODIFIED, 2)
+        _assert_event(next(gen), 3, ADDED, 1)
+        _assert_event(next(gen), 4, ADDED, 2)
+        _assert_event(next(gen), 5, ADDED, 1)
+        _assert_event(next(gen), 6, MODIFIED, 2)
 
         # Third batch
-        _assert_event(next(gen), 1, DELETED, 2)
-        _assert_event(next(gen), 2, MODIFIED, 2)
+        _assert_event(next(gen), 7, ADDED, 2)
+        _assert_event(next(gen), 8, DELETED, 2)
+        _assert_event(next(gen), 9, ADDED, 1)
 
         # Fourth batch
-        _assert_event(next(gen), 0, ADDED, 1, "other")
-        _assert_event(next(gen), 0, MODIFIED, 2, "other")
+        _assert_event(next(gen), 25, ADDED, 2)
+        _assert_event(next(gen), 26, ADDED, 1)
+        _assert_event(next(gen), 27, MODIFIED, 2)
 
         watcher._run_forever = False
         assert list(gen) == []
@@ -115,22 +120,27 @@ class TestWatcher(object):
 
         assert list(gen) == []
 
-        api_watch_list.assert_called_with(namespace=namespace)
+        api_watch_list.assert_called_with(namespace=namespace, start_at_resource_version=None)
 
 
-def _event(id, event_type, rv, namespace="default"):
-    metadict = {"name": "name{}".format(id), "namespace": namespace, "resourceVersion": rv}
-    metadata = ObjectMeta.from_dict(metadict)
-    wle = WatchListExample(metadata=metadata, value=(id * 100) + rv)
-    return mock.NonCallableMagicMock(type=event_type, object=wle)
+def _event(id, event_type, rv):
+    event_json = {
+        "type": event_type,
+        "object": {
+            "value": (id * 100) + rv,
+            "metadata": {
+                "resourceVersion": rv
+            }
+        },
+    }
+    we = WatchEvent(event_json, WatchListExample)
+    return mock.NonCallableMagicMock(type=event_type, object=we)
 
 
-def _assert_event(event, id, event_type, rv, namespace="default"):
+def _assert_event(event, id, event_type, rv):
     assert event.type == event_type
-    o = event.object
+    o = event.object.object
     assert o.kind == "Example"
-    assert o.metadata.name == "name{}".format(id)
-    assert o.metadata.namespace == namespace
     assert o.value == (id * 100) + rv
 
 


### PR DESCRIPTION
This PR is in response to #70 and #71. 

I modified the `k8s.watcher` module to:
- observe `Bookmark` events without forwarding them to the listener
- restart the watch from the last observed event's resource version
- remove the old cache logic, which no longer required since we no longer replay watch event history from the beginning
- add the ability to start a watch from a particular resource version onwards (through the `start_at_resource_version` parameter)

Please let me know what you think.