### PR TITLE
fix apiversion in test

### DIFF
--- a/tests/k8s/test_role.py
+++ b/tests/k8s/test_role.py
@@ -90,7 +90,7 @@ def _create_default_role():
     object_meta = ObjectMeta(name=NAME, namespace=NAMESPACE, labels={"test": "true"})
     policy_rules = [
         PolicyRule(
-            apiGroups=["fiaas-schibsted.io"],
+            apiGroups=["fiaas.schibsted.io"],
             resources=["applications", "application-statuses"],
             verbs=["get", "list", "watch"],
             resourceNames=[],


### PR DESCRIPTION
There was a typo made at some point in the apiversion for fiaas.schibsted.io. This PR resolves that typo.