### PR TITLE
Add simple entrypoint for in-cluster config with BoundServiceAccountTokenVolume support

### DIFF
--- a/k8s/client.py
+++ b/k8s/client.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -99,7 +99,9 @@ class Client(object):
 
     @classmethod
     def init_session(cls):
-        if "Authorization" not in cls._session.headers and config.api_token:
+        if config.api_token_source:
+            cls._session.headers["Authorization"] = "Bearer {}".format(config.api_token_source.token())
+        elif "Authorization" not in cls._session.headers and config.api_token:
             cls._session.headers.update({"Authorization": "Bearer {}".format(config.api_token)})
         if cls._session.cert is None and config.cert:
             cls._session.cert = config.cert

--- a/k8s/config.py
+++ b/k8s/config.py
@@ -2,18 +2,21 @@
 # -*- coding: utf-8
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from datetime import datetime, timedelta, MINYEAR
+import os.path
 
 
 """Singleton configuration for k8s client"""
@@ -22,6 +25,8 @@
 api_server = "https://kubernetes.default.svc.cluster.local"
 #: API token
 api_token = ""
+# Used by in_cluster_configuration. Takes precedence over `api_token` and `cert`.
+api_token_source = None
 #: API certificate
 cert = None
 #: Should the client verify the servers SSL certificates?
@@ -34,3 +39,40 @@ timeout = 20
 stream_timeout = 3600
 #: Default size of Watcher cache
 watcher_cache_size = 1000
+
+
+def use_in_cluster_config(token_file="/var/run/secrets/kubernetes.io/serviceaccount/token",
+                          ca_cert_file="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"):
+    """
+    Configure the client using the recommended configuration for accessing the API from within a Kubernetes cluster:
+    https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
+    """
+    global api_token_source
+    global verify_ssl
+    api_token_source = FileTokenSource(token_file)
+    if os.path.exists(ca_cert_file):
+        verify_ssl = ca_cert_file
+
+
+class FileTokenSource(object):
+    """Read API token from token_file, exposing it via token(). Calls to token() will re-read the token from file if
+    more than 1 minute has passed since the last read.
+
+    Intended to support the BoundServiceAccountTokenVolume feature in Kubernetes 1.21 and later.
+    """
+    def __init__(self, token_file, now_func=datetime.now):
+        self._token_file = token_file
+        self._expires_at = datetime(MINYEAR, 1, 1)  # force read on initial call to _refresh_token
+        self._refresh_interval = timedelta(minutes=1)
+        self._token = self._refresh_token(now_func=now_func)  # fail on init if token_file can not be read
+
+    def token(self, now_func=datetime.now):
+        return self._refresh_token(now_func=now_func)
+
+    def _refresh_token(self, now_func=datetime.now):
+        now = now_func()
+        if self._expires_at <= now:
+            with open(self._token_file, 'r') as f:
+                self._token = f.read().strip()
+                self._expires_at = now + self._refresh_interval
+        return self._token

--- a/k8s/config.py
+++ b/k8s/config.py
@@ -41,7 +41,8 @@ stream_timeout = 3600
 watcher_cache_size = 1000
 
 
-def use_in_cluster_config(token_file="/var/run/secrets/kubernetes.io/serviceaccount/token",
+# disables bandit warning for this line which triggers because the string contains 'token', which is fine
+def use_in_cluster_config(token_file="/var/run/secrets/kubernetes.io/serviceaccount/token",  # nosec
                           ca_cert_file="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"):
     """
     Configure the client using the recommended configuration for accessing the API from within a Kubernetes cluster:

--- a/tests/k8s/test_config.py
+++ b/tests/k8s/test_config.py
@@ -5,6 +5,7 @@ import pytest
 from k8s.config import FileTokenSource
 
 
+# pylint: disable=R0201
 class TestFileTokenSource(object):
 
     @pytest.fixture
@@ -17,14 +18,14 @@ class TestFileTokenSource(object):
                 fpath.remove()
 
     def test_token_read(self, token_file):
-        token = "secret token"
+        token = "secret token"  # nosec
         token_file.write(token)
         token_source = FileTokenSource(token_file=str(token_file))
 
         assert token_source.token() == token
 
     def test_token_re_read_after_expiry(self, token_file):
-        initial_token = "secret token 1"
+        initial_token = "secret token 1"  # nosec
         token_file.write(initial_token)
         initial_time = datetime(2021, 1, 1, 10, 10)
 
@@ -32,7 +33,7 @@ class TestFileTokenSource(object):
 
         assert token_source.token(now_func=lambda: initial_time) == initial_token
 
-        updated_token = "secret token 2"
+        updated_token = "secret token 2"  # nosec
         token_file.write(updated_token)
 
         assert token_source.token(now_func=lambda: initial_time + timedelta(seconds=30)) == initial_token

--- a/tests/k8s/test_config.py
+++ b/tests/k8s/test_config.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from k8s.config import FileTokenSource
+
+
+class TestFileTokenSource(object):
+
+    @pytest.fixture
+    def token_file(self, tmpdir_factory):
+        fpath = tmpdir_factory.mktemp(self.__class__.__name__).join('token_file')
+        try:
+            yield fpath
+        finally:
+            if fpath.exists():
+                fpath.remove()
+
+    def test_token_read(self, token_file):
+        token = "secret token"
+        token_file.write(token)
+        token_source = FileTokenSource(token_file=str(token_file))
+
+        assert token_source.token() == token
+
+    def test_token_re_read_after_expiry(self, token_file):
+        initial_token = "secret token 1"
+        token_file.write(initial_token)
+        initial_time = datetime(2021, 1, 1, 10, 10)
+
+        token_source = FileTokenSource(token_file=str(token_file), now_func=lambda: initial_time)
+
+        assert token_source.token(now_func=lambda: initial_time) == initial_token
+
+        updated_token = "secret token 2"
+        token_file.write(updated_token)
+
+        assert token_source.token(now_func=lambda: initial_time + timedelta(seconds=30)) == initial_token
+        assert token_source.token(now_func=lambda: initial_time + timedelta(minutes=2)) == updated_token
+
+    def test_token_raise_if_file_does_not_exist(self, token_file):
+        with pytest.raises(IOError):
+            FileTokenSource(token_file=str(token_file))


### PR DESCRIPTION
Provide a simple, no parameters required, entrypoint (`k8s.config.use_in_cluster_config`) for configuring the client library following the recommendations for [accessing the API for pods running in a Kubernetes cluster](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod)]

When configuring the client library in this manner, read the service account API token from file every 1 minute ([as recommended](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#api-change-2)) to work with the [BoundServiceAccountTokenVolume feature](https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/1205-bound-service-account-tokens).

Closes #98

~I'm setting this as draft as I need to test this a bit before it is entirely ready to review.~