### PR TITLE
Add nodeName support in podSpec

### DIFF
--- a/k8s/models/pod.py
+++ b/k8s/models/pod.py
@@ -212,6 +212,7 @@ class PodSpec(Model):
     terminationGracePeriodSeconds = Field(int)
     activeDeadlineSeconds = Field(int)
     dnsPolicy = Field(six.text_type, "ClusterFirst")
+    nodeName = Field(six.text_type)
     nodeSelector = Field(dict)
     selector = Field(dict)
     serviceAccountName = Field(six.text_type, "default")


### PR DESCRIPTION
podSpec have a nodeName field for node selection, currently the lib not support that one. So, if you scale down/up a deployment the existing nodeName content will be erased. Fixed with this merge request! 

PodSpec: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#pod-v1-core