### PR TITLE
Make Secret.stringData field work properly

### DIFF
--- a/k8s/fields.py
+++ b/k8s/fields.py
@@ -124,8 +124,8 @@ class ReadOnlyField(Field):
 class WriteOnlyField(Field):
     """WriteOnlyField can only be set"""
 
-    def __get__(self, instance, obj_type=None):
-        pass
+    def _from_dict(self, value):
+        return self.default_value
 
 
 class OnceField(Field):

--- a/tests/k8s/test_secret.py
+++ b/tests/k8s/test_secret.py
@@ -29,6 +29,7 @@ NAMESPACE = "my-namespace"
 STRING_DATA = {"boo": "baz"}
 
 
+# pylint: disable=R0201
 @pytest.mark.usefixtures("k8s_config")
 class TestSecret(object):
     def test_created_if_not_exists(self, post, api_get):


### PR DESCRIPTION
It turns out that the WriteOnlyField doesn't really work the way it was implemented.

I've changed it to just drop any values from the API server, which is the behavior that probably is most correct.
