### PR TITLE
Follow up: adding status field for Application

### DIFF
--- a/k8s/base.py
+++ b/k8s/base.py
@@ -189,6 +189,12 @@ class ApiMixIn(object):
             resp = self._client.put(url, self.as_dict())
         self.update_from_dict(resp.json())
 
+    def save_status(self):
+        """Save status to API server, always updating"""
+        url = self._build_url(name=self.metadata.name, namespace=self.metadata.namespace) + "/status"
+        resp = self._client.put(url, self.as_dict())
+        self.update_from_dict(resp.json())
+
     @staticmethod
     def _label_selector(labels):
         """ Build a labelSelector string from a collection of key/values. The parameter can be either

--- a/k8s/models/apiextensions_v1_custom_resource_definition.py
+++ b/k8s/models/apiextensions_v1_custom_resource_definition.py
@@ -73,6 +73,31 @@ class JSONSchemaProps(Model):
     x_kubernetes_preserve_unknown_fields = Field(bool, name="x-kubernetes-preserve-unknown-fields")
 
 
+class JSONSchemaPropsStatusEnabled(Model):
+    ref = Field(str, name='$ref')
+    schema = Field(str, name='$schema')
+
+    description = Field(str)
+    example = JSONField()
+    exclusiveMaximum = Field(bool)
+    exclusiveMinimum = Field(bool)
+    externalDocs = Field(ExternalDocumentation)
+    format = Field(str)
+    items = Field(SelfModel, alt_type=list)
+    maxItems = Field(int)
+    maxLength = Field(int)
+    maximum = Field(int, alt_type=float)
+    minItems = Field(int)
+    minLength = Field(int)
+    minimum = Field(int, alt_type=float)
+    multipleOf = Field(int, alt_type=float)
+    pattern = Field(str)
+    properties = Field(dict)
+    required = ListField(str)
+    title = Field(str)
+    type = Field(str)
+
+
 class ServiceReference(Model):
     name = Field(str)
     namespace = Field(str)
@@ -115,7 +140,7 @@ class CustomResourceDefinitionNames(Model):
 
 
 class CustomResourceValidation(Model):
-    openAPIV3Schema = Field(JSONSchemaProps)
+    openAPIV3Schema = Field(JSONSchemaProps, alt_type=JSONSchemaPropsStatusEnabled)
 
 
 class CustomResourceSubresourceScale(Model):

--- a/tests/k8s/test_deployer.py
+++ b/tests/k8s/test_deployer.py
@@ -81,6 +81,20 @@ class TestDeployer(object):
         Deployment.delete(NAME, namespace=NAMESPACE)
         pytest.helpers.assert_any_call(delete, _uri(NAMESPACE, NAME))
 
+    def test_save_status(self, get, put):
+        mock_response = _create_mock_response()
+        get.return_value = mock_response
+        deployment = _create_default_deployment()
+
+        from_api = Deployment.get_or_create(metadata=deployment.metadata, spec=deployment.spec)
+        assert not from_api._new
+        assert from_api.spec.replicas == 2
+        call_params = from_api.as_dict()
+        put.return_value.json.return_value = call_params
+
+        from_api.save_status()
+        pytest.helpers.assert_any_call(put, _uri(NAMESPACE, NAME) + "/status", call_params)
+
 
 def _create_default_deployment():
     labels = {"test": "true"}


### PR DESCRIPTION
Follow-up of [PR#114](https://github.com/fiaas/k8s/pull/114) to add status for Application object.

We've took the work from the original author, added tests and improvements as per Øyvind's review.

@oyvindio @mika-hjalmarsson 