### PR TITLE
Move status to a class

### DIFF
--- a/k8s/models/apiextensions_v1_custom_resource_definition.py
+++ b/k8s/models/apiextensions_v1_custom_resource_definition.py
@@ -148,13 +148,13 @@ class CustomResourceSubresourceScale(Model):
     specReplicasPath = Field(str)
     statusReplicasPath = Field(str)
 
+
 class CustomResourceSubresourceStatus(Model):
     pass
 
+
 class CustomResourceSubresources(Model):
     scale = Field(CustomResourceSubresourceScale)
-    # CustomResourceSubresourceStatus contains no fields,
-    # so we use the dict type instead
     status = Field(CustomResourceSubresourceStatus)
 
 

--- a/k8s/models/apiextensions_v1_custom_resource_definition.py
+++ b/k8s/models/apiextensions_v1_custom_resource_definition.py
@@ -148,12 +148,14 @@ class CustomResourceSubresourceScale(Model):
     specReplicasPath = Field(str)
     statusReplicasPath = Field(str)
 
+class CustomResourceSubresourceStatus(Model):
+    pass
 
 class CustomResourceSubresources(Model):
     scale = Field(CustomResourceSubresourceScale)
     # CustomResourceSubresourceStatus contains no fields,
     # so we use the dict type instead
-    status = Field(dict)
+    status = Field(CustomResourceSubresourceStatus)
 
 
 class CustomResourceDefinitionVersion(Model):


### PR DESCRIPTION
When trying to add an empty dict to the status, the JSON formatter we use deletes the field.
As this is needed to enable the /status endpoint, we are changing the definition to create an empty class instead of a dict.

