### PR TITLE
Fix Status subresource

### DIFF
--- a/k8s/models/apiextensions_v1_custom_resource_definition.py
+++ b/k8s/models/apiextensions_v1_custom_resource_definition.py
@@ -150,7 +150,8 @@ class CustomResourceSubresourceScale(Model):
 
 
 class CustomResourceSubresourceStatus(Model):
-    pass
+    def _as_dict(self, value):
+        return {}
 
 
 class CustomResourceSubresources(Model):


### PR DESCRIPTION
The status Field needs to override the `_as_dict` method.