### PR TITLE
Add test for CRD with status subresource and without

### DIFF
--- a/k8s/fields.py
+++ b/k8s/fields.py
@@ -215,8 +215,3 @@ class JSONField(Field):
     @property
     def default_value(self):
         return copy.copy(self._default_value)
-
-
-class EmptyField(Field):
-    def _as_dict(self, value):
-        return {}

--- a/k8s/models/apiextensions_v1_custom_resource_definition.py
+++ b/k8s/models/apiextensions_v1_custom_resource_definition.py
@@ -149,7 +149,11 @@ class CustomResourceSubresourceScale(Model):
     statusReplicasPath = Field(str)
 
 
-class CustomResourceSubresources(Model):
+class CustomResourceSubresourcesStatusDisabled(Model):
+    scale = Field(CustomResourceSubresourceScale)
+
+
+class CustomResourceSubresourcesStatusEnabled(Model):
     scale = Field(CustomResourceSubresourceScale)
     status = EmptyField(dict)
 
@@ -162,7 +166,8 @@ class CustomResourceDefinitionVersion(Model):
     schema = Field(CustomResourceValidation)
     served = Field(bool)
     storage = Field(bool)
-    subresources = Field(CustomResourceSubresources)
+    subresources = Field(CustomResourceSubresourcesStatusEnabled,
+                         alt_type=CustomResourceSubresourcesStatusDisabled)
 
 
 class CustomResourceDefinitionSpec(Model):

--- a/k8s/models/apiextensions_v1_custom_resource_definition.py
+++ b/k8s/models/apiextensions_v1_custom_resource_definition.py
@@ -19,7 +19,7 @@ import datetime
 
 from .common import ObjectMeta
 from ..base import Model, SelfModel
-from ..fields import Field, ListField, JSONField, EmptyField
+from ..fields import Field, ListField, JSONField
 
 
 class ExternalDocumentation(Model):
@@ -149,13 +149,18 @@ class CustomResourceSubresourceScale(Model):
     statusReplicasPath = Field(str)
 
 
-class CustomResourceSubresourcesStatusDisabled(Model):
-    scale = Field(CustomResourceSubresourceScale)
+class CustomResourceSubresourceStatusEnabled(Model):
+    def as_dict(self):
+        return {}
 
 
-class CustomResourceSubresourcesStatusEnabled(Model):
+class CustomResourceSubresourceStatusDisabled(Model):
+    pass
+
+
+class CustomResourceSubresources(Model):
     scale = Field(CustomResourceSubresourceScale)
-    status = EmptyField(dict)
+    status = Field(CustomResourceSubresourceStatusDisabled, alt_type=CustomResourceSubresourceStatusEnabled)
 
 
 class CustomResourceDefinitionVersion(Model):
@@ -166,8 +171,7 @@ class CustomResourceDefinitionVersion(Model):
     schema = Field(CustomResourceValidation)
     served = Field(bool)
     storage = Field(bool)
-    subresources = Field(CustomResourceSubresourcesStatusEnabled,
-                         alt_type=CustomResourceSubresourcesStatusDisabled)
+    subresources = Field(CustomResourceSubresources)
 
 
 class CustomResourceDefinitionSpec(Model):

--- a/tests/k8s/test_apiextensions_v1_custom_resource_definition.py
+++ b/tests/k8s/test_apiextensions_v1_custom_resource_definition.py
@@ -24,7 +24,8 @@ from k8s.models.common import ObjectMeta
 from k8s.models.apiextensions_v1_custom_resource_definition import (
     CustomResourceConversion, CustomResourceDefinition, CustomResourceDefinitionNames,
     CustomResourceDefinitionSpec, CustomResourceDefinitionVersion, JSONSchemaProps,
-    CustomResourceSubresources)
+    CustomResourceSubresourcesStatusEnabled, CustomResourceSubresourcesStatusDisabled,
+    CustomResourceSubresourceScale)
 
 NAME = "my-name"
 
@@ -88,21 +89,43 @@ class TestCustomResourceDefinition(object):
             crd.save()
             pytest.helpers.assert_any_call(put, _uri(NAME), call_params)
 
-    def test_custom_resource_definition_with_status_enabled(self, post, api_get):
-        api_get.side_effect = NotFound()
+    def test_custom_resource_definition_with_status_enabled(self):
+
+        crd = _create_subresource_with_status_enabled_crd(status={})
+
+        result = crd.as_dict()
+
+        assert 'status' in result['spec']['versions'][0]['subresources']
+
+    def test_custom_resource_definition_with_no_subresource_enabled_version(self):
         crd = _create_subresource_with_status_enabled_crd()
-        call_params = crd.as_dict()
-        post.return_value.json.return_value = call_params
 
-        assert crd.as_dict()['spec']['versions'][0]['subresources'] == {'status': {}}
+        result = crd.as_dict()
 
-    def test_custom_resource_definition_with_status_disabled(self, post, api_get):
-        api_get.side_effect = NotFound()
+        assert 'subresources' not in result['spec']['versions'][0]
+
+    def test_custom_resource_definition_with_no_subresource_disabled_version(self):
         crd = _create_subresource_with_status_disabled_crd()
-        call_params = crd.as_dict()
-        post.return_value.json.return_value = call_params
 
-        assert 'subresources' not in crd.as_dict()['spec']['versions'][0]
+        result = crd.as_dict()
+
+        assert 'subresources' not in result['spec']['versions'][0]
+
+    def test_custom_resource_definition_with_scale_and_status_enabled(self):
+        crd = _create_subresource_with_status_enabled_crd(scale=_create_subresource_scale())
+
+        result = crd.as_dict()
+
+        assert 'scale' in result['spec']['versions'][0]['subresources']
+        assert 'status' in result['spec']['versions'][0]['subresources']
+
+    def test_custom_resource_definition_with_scale_and_status_disabled(self):
+        crd = _create_subresource_with_status_disabled_crd(scale=_create_subresource_scale())
+
+        result = crd.as_dict()
+
+        assert 'scale' in result['spec']['versions'][0]['subresources']
+        assert 'status' not in result['spec']['versions'][0]['subresources']
 
 
 def _json_schema_props_crd_dict(default=None):
@@ -207,32 +230,40 @@ def _create_default_crd():
     return crd
 
 
-def _create_subresource_with_status_enabled_crd():
+def _create_subresource_with_status_enabled_crd(scale=None, status=None):
     object_meta = ObjectMeta(name=NAME, labels={"test": "true"})
+    subresources = CustomResourceSubresourcesStatusEnabled(status=status, scale=scale)
     spec = CustomResourceDefinitionSpec(
         conversion=CustomResourceConversion(strategy="None"),
         group="example.com",
         names=CustomResourceDefinitionNames(kind="MyCustomResource", plural="mycustomresources"),
         scope="Namespaced",
         versions=[CustomResourceDefinitionVersion(name="v42", served=True,
-                                                  subresources=CustomResourceSubresources(status={}))]
+                                                  subresources=subresources)]
     )
     crd = CustomResourceDefinition(metadata=object_meta, spec=spec)
     return crd
 
 
-def _create_subresource_with_status_disabled_crd():
+def _create_subresource_with_status_disabled_crd(scale=None):
     object_meta = ObjectMeta(name=NAME, labels={"test": "true"})
+    subresources = CustomResourceSubresourcesStatusDisabled(scale=scale)
     spec = CustomResourceDefinitionSpec(
         conversion=CustomResourceConversion(strategy="None"),
         group="example.com",
         names=CustomResourceDefinitionNames(kind="MyCustomResource", plural="mycustomresources"),
         scope="Namespaced",
         versions=[CustomResourceDefinitionVersion(name="v42", served=True,
-                                                  subresources=CustomResourceSubresources())]
+                                                  subresources=subresources)]
     )
     crd = CustomResourceDefinition(metadata=object_meta, spec=spec)
     return crd
+
+
+def _create_subresource_scale():
+    return CustomResourceSubresourceScale(labelSelectorPath="label",
+                                          specReplicasPath="spec",
+                                          statusReplicasPath="status")
 
 
 def _uri(name=""):

--- a/tests/k8s/test_apiextensions_v1_custom_resource_definition.py
+++ b/tests/k8s/test_apiextensions_v1_custom_resource_definition.py
@@ -24,8 +24,8 @@ from k8s.models.common import ObjectMeta
 from k8s.models.apiextensions_v1_custom_resource_definition import (
     CustomResourceConversion, CustomResourceDefinition, CustomResourceDefinitionNames,
     CustomResourceDefinitionSpec, CustomResourceDefinitionVersion, JSONSchemaProps,
-    CustomResourceSubresourcesStatusEnabled, CustomResourceSubresourcesStatusDisabled,
-    CustomResourceSubresourceScale)
+    CustomResourceSubresourceScale, CustomResourceSubresourceStatusEnabled, CustomResourceSubresources,
+    CustomResourceSubresourceStatusDisabled)
 
 NAME = "my-name"
 
@@ -89,43 +89,33 @@ class TestCustomResourceDefinition(object):
             crd.save()
             pytest.helpers.assert_any_call(put, _uri(NAME), call_params)
 
-    def test_custom_resource_definition_with_status_enabled(self):
-
-        crd = _create_subresource_with_status_enabled_crd(status={})
-
-        result = crd.as_dict()
-
-        assert 'status' in result['spec']['versions'][0]['subresources']
-
-    def test_custom_resource_definition_with_no_subresource_enabled_version(self):
-        crd = _create_subresource_with_status_enabled_crd()
-
-        result = crd.as_dict()
-
-        assert 'subresources' not in result['spec']['versions'][0]
-
-    def test_custom_resource_definition_with_no_subresource_disabled_version(self):
-        crd = _create_subresource_with_status_disabled_crd()
+    @pytest.mark.parametrize("subresources,scale,status,expected_scale,expected_status", [
+        (False, False, None, False, False),
+        (True, False, None, False, False),
+        (True, True, None, True, False),
+        (True, False, CustomResourceSubresourceStatusEnabled(), False, True),
+        (True, True, CustomResourceSubresourceStatusEnabled(), True, True),
+        (True, True, CustomResourceSubresourceStatusDisabled(), True, False),
+    ])
+    def test_custom_resource_definition_with_status_enabled_version(self, subresources, scale, status,
+                                                                    expected_scale, expected_status):
+        subr = _create_subresource(status, scale) if subresources else None
+        crd = _create_default_crd(subr)
 
         result = crd.as_dict()
 
-        assert 'subresources' not in result['spec']['versions'][0]
-
-    def test_custom_resource_definition_with_scale_and_status_enabled(self):
-        crd = _create_subresource_with_status_enabled_crd(scale=_create_subresource_scale())
-
-        result = crd.as_dict()
-
-        assert 'scale' in result['spec']['versions'][0]['subresources']
-        assert 'status' in result['spec']['versions'][0]['subresources']
-
-    def test_custom_resource_definition_with_scale_and_status_disabled(self):
-        crd = _create_subresource_with_status_disabled_crd(scale=_create_subresource_scale())
-
-        result = crd.as_dict()
-
-        assert 'scale' in result['spec']['versions'][0]['subresources']
-        assert 'status' not in result['spec']['versions'][0]['subresources']
+        if subresources and (expected_scale or expected_status):
+            assert 'subresources' in result['spec']['versions'][0]
+            if expected_scale:
+                assert 'scale' in result['spec']['versions'][0]['subresources']
+            else:
+                assert 'scale' not in result['spec']['versions'][0]['subresources']
+            if expected_status:
+                assert 'status' in result['spec']['versions'][0]['subresources']
+            else:
+                assert 'status' not in result['spec']['versions'][0]['subresources']
+        else:
+            assert 'subresources' not in result['spec']['versions'][0]
 
 
 def _json_schema_props_crd_dict(default=None):
@@ -217,47 +207,22 @@ def _create_mock_response():
     return mock_response
 
 
-def _create_default_crd():
+def _create_default_crd(subresources=None):
     object_meta = ObjectMeta(name=NAME, labels={"test": "true"})
     spec = CustomResourceDefinitionSpec(
         conversion=CustomResourceConversion(strategy="None"),
         group="example.com",
         names=CustomResourceDefinitionNames(kind="MyCustomResource", plural="mycustomresources"),
         scope="Namespaced",
-        versions=[CustomResourceDefinitionVersion(name="v42", served=True)]
+        versions=[CustomResourceDefinitionVersion(name="v42", served=True, subresources=subresources)],
     )
     crd = CustomResourceDefinition(metadata=object_meta, spec=spec)
     return crd
 
 
-def _create_subresource_with_status_enabled_crd(scale=None, status=None):
-    object_meta = ObjectMeta(name=NAME, labels={"test": "true"})
-    subresources = CustomResourceSubresourcesStatusEnabled(status=status, scale=scale)
-    spec = CustomResourceDefinitionSpec(
-        conversion=CustomResourceConversion(strategy="None"),
-        group="example.com",
-        names=CustomResourceDefinitionNames(kind="MyCustomResource", plural="mycustomresources"),
-        scope="Namespaced",
-        versions=[CustomResourceDefinitionVersion(name="v42", served=True,
-                                                  subresources=subresources)]
-    )
-    crd = CustomResourceDefinition(metadata=object_meta, spec=spec)
-    return crd
-
-
-def _create_subresource_with_status_disabled_crd(scale=None):
-    object_meta = ObjectMeta(name=NAME, labels={"test": "true"})
-    subresources = CustomResourceSubresourcesStatusDisabled(scale=scale)
-    spec = CustomResourceDefinitionSpec(
-        conversion=CustomResourceConversion(strategy="None"),
-        group="example.com",
-        names=CustomResourceDefinitionNames(kind="MyCustomResource", plural="mycustomresources"),
-        scope="Namespaced",
-        versions=[CustomResourceDefinitionVersion(name="v42", served=True,
-                                                  subresources=subresources)]
-    )
-    crd = CustomResourceDefinition(metadata=object_meta, spec=spec)
-    return crd
+def _create_subresource(status, has_scale):
+    scale = _create_subresource_scale() if has_scale else None
+    return CustomResourceSubresources(status=status, scale=scale)
 
 
 def _create_subresource_scale():

--- a/tests/k8s/test_apiextensions_v1_custom_resource_definition.py
+++ b/tests/k8s/test_apiextensions_v1_custom_resource_definition.py
@@ -23,7 +23,8 @@ from k8s.client import NotFound
 from k8s.models.common import ObjectMeta
 from k8s.models.apiextensions_v1_custom_resource_definition import (
     CustomResourceConversion, CustomResourceDefinition, CustomResourceDefinitionNames,
-    CustomResourceDefinitionSpec, CustomResourceDefinitionVersion, JSONSchemaProps)
+    CustomResourceDefinitionSpec, CustomResourceDefinitionVersion, JSONSchemaProps,
+    CustomResourceSubresources)
 
 NAME = "my-name"
 
@@ -86,6 +87,22 @@ class TestCustomResourceDefinition(object):
 
             crd.save()
             pytest.helpers.assert_any_call(put, _uri(NAME), call_params)
+
+    def test_custom_resource_definition_with_status_enabled(self, post, api_get):
+        api_get.side_effect = NotFound()
+        crd = _create_subresource_with_status_enabled_crd()
+        call_params = crd.as_dict()
+        post.return_value.json.return_value = call_params
+
+        assert crd.as_dict()['spec']['versions'][0]['subresources'] == {'status': {}}
+
+    def test_custom_resource_definition_with_status_disabled(self, post, api_get):
+        api_get.side_effect = NotFound()
+        crd = _create_subresource_with_status_disabled_crd()
+        call_params = crd.as_dict()
+        post.return_value.json.return_value = call_params
+
+        assert 'subresources' not in crd.as_dict()['spec']['versions'][0]
 
 
 def _json_schema_props_crd_dict(default=None):
@@ -185,6 +202,34 @@ def _create_default_crd():
         names=CustomResourceDefinitionNames(kind="MyCustomResource", plural="mycustomresources"),
         scope="Namespaced",
         versions=[CustomResourceDefinitionVersion(name="v42", served=True)]
+    )
+    crd = CustomResourceDefinition(metadata=object_meta, spec=spec)
+    return crd
+
+
+def _create_subresource_with_status_enabled_crd():
+    object_meta = ObjectMeta(name=NAME, labels={"test": "true"})
+    spec = CustomResourceDefinitionSpec(
+        conversion=CustomResourceConversion(strategy="None"),
+        group="example.com",
+        names=CustomResourceDefinitionNames(kind="MyCustomResource", plural="mycustomresources"),
+        scope="Namespaced",
+        versions=[CustomResourceDefinitionVersion(name="v42", served=True,
+                                                  subresources=CustomResourceSubresources(status={}))]
+    )
+    crd = CustomResourceDefinition(metadata=object_meta, spec=spec)
+    return crd
+
+
+def _create_subresource_with_status_disabled_crd():
+    object_meta = ObjectMeta(name=NAME, labels={"test": "true"})
+    spec = CustomResourceDefinitionSpec(
+        conversion=CustomResourceConversion(strategy="None"),
+        group="example.com",
+        names=CustomResourceDefinitionNames(kind="MyCustomResource", plural="mycustomresources"),
+        scope="Namespaced",
+        versions=[CustomResourceDefinitionVersion(name="v42", served=True,
+                                                  subresources=CustomResourceSubresources())]
     )
     crd = CustomResourceDefinition(metadata=object_meta, spec=spec)
     return crd


### PR DESCRIPTION
Added test and improvements commented in [PR#118](https://github.com/fiaas/k8s/pull/118).
