### PR TITLE
Generate API docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,12 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.9"
+  apt_packages:
+    - make
+  jobs:
+    pre_build:
+      # generate API reference docs .rst files from module source
+      - make -C docs/ apidocs
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
It looks like #122 fixed the documentation build, so https://k8s.readthedocs.io/en/latest is updated now. Module API docs from doc strings via autodoc seems to be missing though. 

Run the apidocs target in the already existing Makefile for generating module API docs before the builtin build command to generate docs is run. 