### PR TITLE
Lower the stream timeout to detect control plan rotation faster.

### DIFF
--- a/k8s/base.py
+++ b/k8s/base.py
@@ -95,11 +95,7 @@ class ApiMixIn(object):
         """
         if namespace is None:
             if not cls._meta.list_url:
-                raise NotImplementedError(
-                    "Cannot find without namespace, no list_url defined on class {}".format(
-                        cls
-                    )
-                )
+                raise NotImplementedError("Cannot find without namespace, no list_url defined on class {}".format(cls))
             url = cls._meta.list_url
         else:
             url = cls._build_url(name="", namespace=namespace)
@@ -114,11 +110,7 @@ class ApiMixIn(object):
         """List all resources in given namespace"""
         if namespace is None:
             if not cls._meta.list_url:
-                raise NotImplementedError(
-                    "Cannot list without namespace, no list_url defined on class {}".format(
-                        cls
-                    )
-                )
+                raise NotImplementedError("Cannot list without namespace, no list_url defined on class {}".format(cls))
             url = cls._meta.list_url
         else:
             url = cls._build_url(name="", namespace=namespace)
@@ -139,9 +131,7 @@ class ApiMixIn(object):
         try:
             # The timeout here appears to be per call to the poll (or similar) system call,
             # so each time data is received, the timeout will reset.
-            resp = cls._client.get(
-                url, stream=True, timeout=config.stream_timeout, params=params
-            )
+            resp = cls._client.get(url, stream=True, timeout=config.stream_timeout, params=params)
             for line in resp.iter_lines(chunk_size=None):
                 event = cls._parse_watch_event(line) if line else None
                 if event:
@@ -167,18 +157,12 @@ class ApiMixIn(object):
                 url = cls._meta.watch_list_url_template.format(namespace=namespace)
             else:
                 raise NotImplementedError(
-                    "Cannot watch_list with namespace, no watch_list_url_template defined on class {}".format(
-                        cls
-                    )
+                    "Cannot watch_list with namespace, no watch_list_url_template defined on class {}".format(cls)
                 )
         else:
             url = cls._meta.watch_list_url
             if not url:
-                raise NotImplementedError(
-                    "Cannot watch_list, no watch_list_url defined on class {}".format(
-                        cls
-                    )
-                )
+                raise NotImplementedError("Cannot watch_list, no watch_list_url defined on class {}".format(cls))
         return url
 
     @classmethod
@@ -199,8 +183,7 @@ class ApiMixIn(object):
             return event
         except TypeError:
             LOG.exception(
-                "Unable to create instance of %s from watch event json, discarding event. "
-                + "event_json=%r",
+                "Unable to create instance of %s from watch event json, discarding event. event_json=%r",
                 cls.__name__,
                 event_json,
             )
@@ -457,7 +440,4 @@ class APIServerError(Exception):
 
     @classmethod
     def match(cls, event_json):
-        return (
-            event_json["type"] == "ERROR"
-            and event_json["object"].get("kind") == "Status"
-        )
+        return event_json["type"] == "ERROR" and event_json["object"].get("kind") == "Status"

--- a/k8s/base.py
+++ b/k8s/base.py
@@ -138,7 +138,7 @@ class ApiMixIn(object):
             # As per https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-watch
             # only resourceVersion is used for watch queries.
             params["resourceVersion"] = resource_version
-            LOG.info(f"Restarting %s watch at resource version %s", cls.__name__, resource_version)
+            LOG.info("Restarting %s watch at resource version %s", cls.__name__, resource_version)
         if allow_bookmarks:
             params["allowWatchBookmarks"] = "true"
 

--- a/k8s/base.py
+++ b/k8s/base.py
@@ -95,7 +95,11 @@ class ApiMixIn(object):
         """
         if namespace is None:
             if not cls._meta.list_url:
-                raise NotImplementedError("Cannot find without namespace, no list_url defined on class {}".format(cls))
+                raise NotImplementedError(
+                    "Cannot find without namespace, no list_url defined on class {}".format(
+                        cls
+                    )
+                )
             url = cls._meta.list_url
         else:
             url = cls._build_url(name="", namespace=namespace)
@@ -103,69 +107,49 @@ class ApiMixIn(object):
             labels = {"app": Equality(name)}
         selector = cls._label_selector(labels)
         resp = cls._client.get(url, params={"labelSelector": selector})
-        return [cls.from_dict(item) for item in resp.json()[u"items"]]
+        return [cls.from_dict(item) for item in resp.json()["items"]]
 
     @classmethod
     def list(cls, namespace="default"):
         """List all resources in given namespace"""
         if namespace is None:
             if not cls._meta.list_url:
-                raise NotImplementedError("Cannot list without namespace, no list_url defined on class {}".format(cls))
+                raise NotImplementedError(
+                    "Cannot list without namespace, no list_url defined on class {}".format(
+                        cls
+                    )
+                )
             url = cls._meta.list_url
         else:
             url = cls._build_url(name="", namespace=namespace)
         resp = cls._client.get(url)
-        return [cls.from_dict(item) for item in resp.json()[u"items"]]
+        return [cls.from_dict(item) for item in resp.json()["items"]]
 
     @classmethod
     def watch_list(cls, namespace=None, resource_version=None):
         """Return a generator that yields WatchEvents of cls"""
-        if namespace:
-            if cls._meta.watch_list_url_template:
-                url = cls._meta.watch_list_url_template.format(namespace=namespace)
-            else:
-                raise NotImplementedError(
-                    "Cannot watch_list with namespace, no watch_list_url_template defined on class {}".format(cls))
-        else:
-            url = cls._meta.watch_list_url
-            if not url:
-                raise NotImplementedError("Cannot watch_list, no watch_list_url defined on class {}".format(cls))
+        url = cls._watch_list_url(namespace)
 
         params = {}
         if resource_version:
             # As per https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-watch
             # only resourceVersion is used for watch queries.
             params["resourceVersion"] = resource_version
+
         try:
-            # The timeout here appears to be per call to the poll (or similar) system call, so each time data is received, the timeout will reset.
-            resp = cls._client.get(url, stream=True, timeout=config.stream_timeout, params=params)
+            # The timeout here appears to be per call to the poll (or similar) system call,
+            # so each time data is received, the timeout will reset.
+            resp = cls._client.get(
+                url, stream=True, timeout=config.stream_timeout, params=params
+            )
             for line in resp.iter_lines(chunk_size=None):
-                if line:
-                    try:
-                        event_json = json.loads(line)
-                        if APIServerError.match(event_json):
-                            LOG.warning(
-                                "Received error event from API server: %s",
-                                event_json["object"]["message"],
-                            )
-                            raise APIServerError(event_json["object"])
-                        try:
-                            event = WatchEvent(event_json, cls)
-                            yield event
-                        except TypeError:
-                            LOG.exception(
-                                "Unable to create instance of %s from watch event json, discarding event. event_json=%r",
-                                cls.__name__,
-                                event_json,
-                            )
-                    except ValueError:
-                        LOG.exception(
-                            "Unable to parse JSON on watch event, discarding event. Line: %r",
-                            line,
-                        )
+                event = cls._parse_watch_event(line) if line else None
+                if event:
+                    yield event
         except requests.ConnectionError as e:
             # ConnectionError is fairly generic, but check for ReadTimeoutError from urllib3.
-            # If we get this, there were no events received for the timeout period, which might not be an error, just a quiet period.
+            # If we get this, there were no events received for the timeout period, which might not be an error,
+            # just a quiet period.
             underlying = e.args[0]
             if isinstance(underlying, urllib3.exceptions.ReadTimeoutError):
                 LOG.info(
@@ -174,6 +158,58 @@ class ApiMixIn(object):
                 )
                 return
             raise
+
+    @classmethod
+    def _watch_list_url(cls, namespace):
+        """Loads the optionally namespaced url from the class meta"""
+        if namespace:
+            if cls._meta.watch_list_url_template:
+                url = cls._meta.watch_list_url_template.format(namespace=namespace)
+            else:
+                raise NotImplementedError(
+                    "Cannot watch_list with namespace, no watch_list_url_template defined on class {}".format(
+                        cls
+                    )
+                )
+        else:
+            url = cls._meta.watch_list_url
+            if not url:
+                raise NotImplementedError(
+                    "Cannot watch_list, no watch_list_url defined on class {}".format(
+                        cls
+                    )
+                )
+        return url
+
+    @classmethod
+    def _parse_watch_event(cls, line):
+        """
+        Parse a line from the watch stream into a WatchEvent.
+        Raises APIServerError if the line is an error event.
+        """
+        try:
+            event_json = json.loads(line)
+            if APIServerError.match(event_json):
+                LOG.warning(
+                    "Received error event from API server: %s",
+                    event_json["object"]["message"],
+                )
+                raise APIServerError(event_json["object"])
+            event = WatchEvent(event_json, cls)
+            return event
+        except TypeError:
+            LOG.exception(
+                "Unable to create instance of %s from watch event json, discarding event. "
+                + "event_json=%r",
+                cls.__name__,
+                event_json,
+            )
+        except ValueError:
+            LOG.exception(
+                "Unable to parse JSON on watch event, discarding event. Line: %r",
+                line,
+            )
+        return None
 
     @classmethod
     def get(cls, name, namespace="default"):
@@ -409,6 +445,7 @@ class SelfModel:
     """
     pass
 
+
 class APIServerError(Exception):
     """Raised when the API server returns an error event in the watch stream"""
 
@@ -420,4 +457,7 @@ class APIServerError(Exception):
 
     @classmethod
     def match(cls, event_json):
-        return event_json["type"] == "ERROR" and event_json["object"].get("kind") == "Status"
+        return (
+            event_json["type"] == "ERROR"
+            and event_json["object"].get("kind") == "Status"
+        )

--- a/k8s/base.py
+++ b/k8s/base.py
@@ -21,6 +21,7 @@ from abc import ABC
 import json
 import logging
 from collections import namedtuple
+from typing import Optional
 
 import requests
 import requests.packages.urllib3 as urllib3
@@ -180,7 +181,7 @@ class ApiMixIn(object):
         return url
 
     @classmethod
-    def _parse_watch_event(cls, line) -> WatchBaseEvent:
+    def _parse_watch_event(cls, line) -> Optional[WatchBaseEvent]:
         """
         Parse a line from the watch stream into a WatchEvent or WatchBookmark.
         Raises APIServerError if the line is an error event.

--- a/k8s/config.py
+++ b/k8s/config.py
@@ -38,10 +38,15 @@ timeout = 20
 #: Default timeout for streaming operations, used while waiting for more events.
 #: When reached, the library will usually info log and reconnect.
 #: There's a few considerations when setting this value:
-#: * On some servers, it might take this long to detect a dropped connection. This speaks for a low value, to detect the issue faster.
-#: * When connecting, a resourceVersion is used to resume, if still valid. This speaks for a low value, to avoid them expiring.
-#: * During idle periods, there might not be any new resourceVersions. Therefore a full quorum read each time a timeout is reached. This speaks for a high value.
-#: 4.5 minutes is the default, set to detect the first case above in a reasonable time, while being just below the default resourceVersion expiration of 5 minutes.
+#: * On some servers, it might take this long to detect a dropped connection. This speaks for a low value,
+#:   to detect the issue faster.
+#: * When connecting, a resourceVersion is used to resume, if still valid. This speaks for a low value,
+#:   to avoid them expiring.
+#: * During idle periods, there might not be any new resourceVersions.
+#:   Therefore a full quorum read each time a timeout is reached.
+#:   This speaks for a high value.
+#: 4.5 minutes is the default, set to detect the first case above in a reasonable time,
+#:while being just below the default resourceVersion expiration of 5 minutes.
 stream_timeout = 270
 #: Default size of Watcher cache. If you expect a lot of events, you might want to increase this.
 watcher_cache_size = 1000

--- a/k8s/config.py
+++ b/k8s/config.py
@@ -35,9 +35,15 @@ verify_ssl = True
 debug = False
 #: Default timeout for most operations
 timeout = 20
-#: Default timeout for streaming operations
-stream_timeout = 3600
-#: Default size of Watcher cache
+#: Default timeout for streaming operations, used while waiting for more events.
+#: When reached, the library will usually info log and reconnect.
+#: There's a few considerations when setting this value:
+#: * On some servers, it might take this long to detect a dropped connection. This speaks for a low value, to detect the issue faster.
+#: * When connecting, a resourceVersion is used to resume, if still valid. This speaks for a low value, to avoid them expiring.
+#: * During idle periods, there might not be any new resourceVersions. Therefore a full quorum read each time a timeout is reached. This speaks for a high value.
+#: 4.5 minutes is the default, set to detect the first case above in a reasonable time, while being just below the default resourceVersion expiration of 5 minutes.
+stream_timeout = 270
+#: Default size of Watcher cache. If you expect a lot of events, you might want to increase this.
 watcher_cache_size = 1000
 
 

--- a/k8s/watcher.py
+++ b/k8s/watcher.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,7 @@
 
 import cachetools
 
-from .base import WatchEvent
+from .base import APIServerError, WatchEvent
 
 DEFAULT_CAPACITY = 1000
 
@@ -36,6 +36,7 @@ class Watcher(object):
     :param Model model: The model class to watch
     :param int capacity: How many seen objects to keep track of
     """
+
     def __init__(self, model, capacity=DEFAULT_CAPACITY):
         self._seen = cachetools.LRUCache(capacity)
         self._model = model
@@ -48,11 +49,26 @@ class Watcher(object):
             watching for events in all namespaces.
         :return: a generator that yields :py:class:`~.WatchEvent` objects not seen before
         """
+        # last_seen_resource_version is used to resume the watch from the last seen event. Only used on reconnects, the first call to watch does a quorum read.
+        last_seen_resource_version = None
         while self._run_forever:
-            for event in self._model.watch_list(namespace=namespace):
-                o = event.object
-                key = (o.metadata.name, o.metadata.namespace)
-                if self._seen.get(key) == o.metadata.resourceVersion and event.type != WatchEvent.DELETED:
-                    continue
-                self._seen[key] = o.metadata.resourceVersion
-                yield event
+            try:
+                for event in self._model.watch_list(
+                    namespace=namespace, resource_version=last_seen_resource_version
+                ):
+                    o = event.object
+                    key = (o.metadata.name, o.metadata.namespace)
+                    last_seen_resource_version = o.metadata.resourceVersion
+                    if (
+                        self._seen.get(key) == o.metadata.resourceVersion
+                        and event.type != WatchEvent.DELETED
+                    ):
+                        continue
+                    self._seen[key] = o.metadata.resourceVersion
+                    yield event
+            except APIServerError as e:
+                # A 410 response indicates our resourceVersion is too old, and we need to do a new quorum read.
+                if e.api_error["code"] == 410:
+                    last_seen_resource_version = None
+                else:
+                    raise

--- a/k8s/watcher.py
+++ b/k8s/watcher.py
@@ -49,7 +49,8 @@ class Watcher(object):
             watching for events in all namespaces.
         :return: a generator that yields :py:class:`~.WatchEvent` objects not seen before
         """
-        # last_seen_resource_version is used to resume the watch from the last seen event. Only used on reconnects, the first call to watch does a quorum read.
+        # last_seen_resource_version is used to resume the watch from the last seen event.
+        # Only used on reconnects, the first call to watch does a quorum read.
         last_seen_resource_version = None
         while self._run_forever:
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 120
+skip_string_normalization = 1

--- a/tests/k8s/test_base.py
+++ b/tests/k8s/test_base.py
@@ -133,7 +133,7 @@ class TestWatchList(object):
             {"type": "ADDED", "object": {"value": 1}}, Example
         )
         client.get.assert_called_once_with(
-            "/watch/example", stream=True, timeout=3600, params={}
+            "/watch/example", stream=True, timeout=270, params={}
         )
         assert list(gen) == []
 
@@ -154,5 +154,5 @@ class TestWatchList(object):
             client.get.return_value.iter_lines.return_value.__getitem__.call_count == 2
         )
         client.get.assert_called_once_with(
-            "/watch/example", stream=True, timeout=3600, params={}
+            "/watch/example", stream=True, timeout=270, params={}
         )

--- a/tests/k8s/test_base.py
+++ b/tests/k8s/test_base.py
@@ -129,12 +129,8 @@ class TestWatchList(object):
             '{"type": "ADDED", "object": {"value": 1}}',
         ]
         gen = Example.watch_list()
-        assert next(gen) == WatchEvent(
-            {"type": "ADDED", "object": {"value": 1}}, Example
-        )
-        client.get.assert_called_once_with(
-            "/watch/example", stream=True, timeout=270, params={}
-        )
+        assert next(gen) == WatchEvent({"type": "ADDED", "object": {"value": 1}}, Example)
+        client.get.assert_called_once_with("/watch/example", stream=True, timeout=270, params={})
         assert list(gen) == []
 
     def test_watch_list_with_timeout(self, client):
@@ -146,13 +142,7 @@ class TestWatchList(object):
         # Seal to avoid __iter__ being used instead of __getitem__
         mock.seal(client)
         gen = Example.watch_list()
-        assert next(gen) == WatchEvent(
-            {"type": "ADDED", "object": {"value": 1}}, Example
-        )
+        assert next(gen) == WatchEvent({"type": "ADDED", "object": {"value": 1}}, Example)
         assert list(gen) == []
-        assert (
-            client.get.return_value.iter_lines.return_value.__getitem__.call_count == 2
-        )
-        client.get.assert_called_once_with(
-            "/watch/example", stream=True, timeout=270, params={}
-        )
+        assert client.get.return_value.iter_lines.return_value.__getitem__.call_count == 2
+        client.get.assert_called_once_with("/watch/example", stream=True, timeout=270, params={})

--- a/tests/k8s/test_base.py
+++ b/tests/k8s/test_base.py
@@ -17,6 +17,8 @@
 
 import mock
 import pytest
+import requests
+import requests.packages.urllib3 as urllib3
 
 from k8s.base import Model, Field, WatchEvent, Equality, Inequality, In, NotIn, Exists
 from k8s.models.common import DeleteOptions, Preconditions
@@ -114,3 +116,43 @@ class TestDeleteList(object):
             "propagationPolicy": "Foreground"
         }
         client.delete.assert_called_once_with("/example", params={"labelSelector": "foo=bar"}, body=expected_body)
+
+
+class TestWatchList(object):
+    @pytest.fixture
+    def client(self):
+        with mock.patch.object(Example, "_client") as m:
+            yield m
+
+    def test_watch_list(self, client):
+        client.get.return_value.iter_lines.return_value = [
+            '{"type": "ADDED", "object": {"value": 1}}',
+        ]
+        gen = Example.watch_list()
+        assert next(gen) == WatchEvent(
+            {"type": "ADDED", "object": {"value": 1}}, Example
+        )
+        client.get.assert_called_once_with(
+            "/watch/example", stream=True, timeout=3600, params={}
+        )
+        assert list(gen) == []
+
+    def test_watch_list_with_timeout(self, client):
+        client.get.return_value.iter_lines.return_value.__getitem__.side_effect = [
+            '{"type": "ADDED", "object": {"value": 1}}',
+            requests.ConnectionError(urllib3.exceptions.ReadTimeoutError("", "", "")),
+            '{"type": "MODIFIED", "object": {"value": 2}}',  # Not reached
+        ]
+        # Seal to avoid __iter__ being used instead of __getitem__
+        mock.seal(client)
+        gen = Example.watch_list()
+        assert next(gen) == WatchEvent(
+            {"type": "ADDED", "object": {"value": 1}}, Example
+        )
+        assert list(gen) == []
+        assert (
+            client.get.return_value.iter_lines.return_value.__getitem__.call_count == 2
+        )
+        client.get.assert_called_once_with(
+            "/watch/example", stream=True, timeout=3600, params={}
+        )

--- a/tests/k8s/test_client.py
+++ b/tests/k8s/test_client.py
@@ -124,13 +124,13 @@ class TestClient(object):
     def test_watch_list(self, session):
         list(WatchListExample.watch_list())
         session.request.assert_called_once_with(
-            "GET", _absolute_url("/watch/example"), json=None, timeout=config.stream_timeout, stream=True
+            "GET", _absolute_url("/watch/example"), json=None, timeout=config.stream_timeout, stream=True, params={}
         )
 
     def test_watch_list_with_namespace(self, session):
         list(WatchListExample.watch_list(namespace="explicitly-set"))
         session.request.assert_called_once_with(
-            "GET", _absolute_url("/watch/explicitly-set/example"), json=None, timeout=config.stream_timeout, stream=True
+            "GET", _absolute_url("/watch/explicitly-set/example"), json=None, timeout=config.stream_timeout, stream=True, params={}
         )
 
     def test_list_without_namespace_should_raise_exception_when_list_url_is_not_set_on_metaclass(self, session):

--- a/tests/k8s/test_client.py
+++ b/tests/k8s/test_client.py
@@ -130,7 +130,12 @@ class TestClient(object):
     def test_watch_list_with_namespace(self, session):
         list(WatchListExample.watch_list(namespace="explicitly-set"))
         session.request.assert_called_once_with(
-            "GET", _absolute_url("/watch/explicitly-set/example"), json=None, timeout=config.stream_timeout, stream=True, params={}
+            "GET",
+            _absolute_url("/watch/explicitly-set/example"),
+            json=None,
+            timeout=config.stream_timeout,
+            stream=True,
+            params={},
         )
 
     def test_list_without_namespace_should_raise_exception_when_list_url_is_not_set_on_metaclass(self, session):


### PR DESCRIPTION
We encountered a problem where fiaas-deploy-daemon would hang for an extended period during a control plan rotation.
A traceback indicated it was still listening for events from the previous control plane, that wasn't sending any. It's still uncertain if this was an active connection or one dropped silently by the server.

Lowering the stream_timeout is the chosen solution, but it comes with a few problems, especially that before this, the watcher thread for exit with an exception when the stream times out. That's solved by cathing the timeout and returning normally. Additionally, resource versions are now supported by the watching, including handling the 410 Gone response.