### PR TITLE
Update codacy grade badge and codacy coverage badge.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,10 +20,8 @@ k8s - Python client library for the Kubernetes API
 
 .. |Semaphore Build Status Badge| image:: https://fiaas-svc.semaphoreci.com/badges/k8s.svg?style=shields
     :target: https://fiaas-svc.semaphoreci.com/branches/8e8fdc8c-cd55-4ba3-9dcf-38880531e601
-.. |Codacy Quality Badge| image:: https://api.codacy.com/project/badge/Grade/cb51fc9f95464f22b6084379e88fad77
-    :target: https://www.codacy.com/app/mortenlj/k8s?utm_source=github.com&utm_medium=referral&utm_content=fiaas/k8s&utm_campaign=badger
-.. |Codacy Coverage Badge| image:: https://api.codacy.com/project/badge/Coverage/cb51fc9f95464f22b6084379e88fad77
-    :target: https://www.codacy.com/app/mortenlj/k8s?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=fiaas/k8s&amp;utm_campaign=Badge_Coverage
+.. |[![Codacy Badge](https://app.codacy.com/project/badge/Grade/4ebbdb3f34b0452fbbf48bb337dc6465)](https://app.codacy.com/gh/fiaas/k8s/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+.. |[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/4ebbdb3f34b0452fbbf48bb337dc6465)](https://app.codacy.com/gh/fiaas/k8s/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
 
 Documentation
     https://k8s.readthedocs.io

--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,8 @@ k8s - Python client library for the Kubernetes API
 
 .. |Semaphore Build Status Badge| image:: https://fiaas-svc.semaphoreci.com/badges/k8s.svg?style=shields
     :target: https://fiaas-svc.semaphoreci.com/branches/8e8fdc8c-cd55-4ba3-9dcf-38880531e601
-.. |[![Codacy Badge](https://app.codacy.com/project/badge/Grade/4ebbdb3f34b0452fbbf48bb337dc6465)](https://app.codacy.com/gh/fiaas/k8s/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
-.. |[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/4ebbdb3f34b0452fbbf48bb337dc6465)](https://app.codacy.com/gh/fiaas/k8s/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
+.. [![Codacy Badge](https://app.codacy.com/project/badge/Grade/4ebbdb3f34b0452fbbf48bb337dc6465)](https://app.codacy.com/gh/fiaas/k8s/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+.. [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/4ebbdb3f34b0452fbbf48bb337dc6465)](https://app.codacy.com/gh/fiaas/k8s/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
 
 Documentation
     https://k8s.readthedocs.io

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@
 k8s - Python client library for the Kubernetes API
 --------------------------------------------------
 
-|Semaphore Build Status Badge| |Codacy Quality Badge| |Codacy Coverage Badge|
+|Semaphore Build Status Badge| |Codacy Grade Badge| |Codacy Coverage Badge|
 
 .. |Semaphore Build Status Badge| image:: https://fiaas-svc.semaphoreci.com/badges/k8s.svg?style=shields
     :target: https://fiaas-svc.semaphoreci.com/branches/8e8fdc8c-cd55-4ba3-9dcf-38880531e601

--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,10 @@ k8s - Python client library for the Kubernetes API
 
 .. |Semaphore Build Status Badge| image:: https://fiaas-svc.semaphoreci.com/badges/k8s.svg?style=shields
     :target: https://fiaas-svc.semaphoreci.com/branches/8e8fdc8c-cd55-4ba3-9dcf-38880531e601
-.. [![Codacy Badge](https://app.codacy.com/project/badge/Grade/4ebbdb3f34b0452fbbf48bb337dc6465)](https://app.codacy.com/gh/fiaas/k8s/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
-.. [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/4ebbdb3f34b0452fbbf48bb337dc6465)](https://app.codacy.com/gh/fiaas/k8s/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
+.. |Codacy Grade Badge| image:: https://app.codacy.com/project/badge/Grade/4ebbdb3f34b0452fbbf48bb337dc6465
+   :target: https://app.codacy.com/gh/fiaas/k8s/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade
+.. |Codacy Coverage Badge| image:: https://app.codacy.com/project/badge/Coverage/4ebbdb3f34b0452fbbf48bb337dc6465
+   :target: https://app.codacy.com/gh/fiaas/k8s/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage
 
 Documentation
     https://k8s.readthedocs.io


### PR DESCRIPTION
Update the codacy badges, which was previously linked with "mortlenlj" in the links.

Also checked that we don't have the "Codacy coverage report" in required status checks which will be removed on the 5th of june 2024 https://docs.codacy.com/release-notes/cloud/cloud-2023-11-23-new-coverage-engine-status-checks/#deprecation-and-removal-of-the-old-coverage-engine-status-checks.