### PR TITLE
Add PodDNSConfig.

### DIFF
--- a/k8s/fields.py
+++ b/k8s/fields.py
@@ -137,13 +137,17 @@ class OnceField(Field):
 class ListField(Field):
     """ListField is a list (array) of a single type on a model"""
 
-    def __init__(self, field_type, default_value=None, name='__unset__'):
+    def __init__(self, field_type, default_value=None, name='__unset__', empty_as_none=False):
         if default_value is None:
             default_value = []
         super(ListField, self).__init__(field_type, default_value, name=name)
+        self._empty_as_none = empty_as_none
 
     def dump(self, instance):
-        return [self._as_dict(v) for v in getattr(instance, self.attr_name)]
+        v = [self._as_dict(v) for v in getattr(instance, self.attr_name)]
+        if self._empty_as_none and not v:
+            return None
+        return v
 
     def load(self, instance, value):
         if value is None:

--- a/k8s/models/pod.py
+++ b/k8s/models/pod.py
@@ -202,6 +202,17 @@ class Volume(Model):
     secret = Field(SecretVolumeSource)
 
 
+class PodDNSConfigOption(Model):
+    name = Field(str)
+    value = Field(str)
+
+
+class PodDNSConfig(Model):
+    nameservers = ListField(str, empty_as_none=True)
+    searches = ListField(str, empty_as_none=True)
+    options = ListField(PodDNSConfigOption, empty_as_none=True)
+
+
 class PodSpec(Model):
     volumes = ListField(Volume)
     containers = ListField(Container)
@@ -209,6 +220,7 @@ class PodSpec(Model):
     terminationGracePeriodSeconds = Field(int)
     activeDeadlineSeconds = Field(int)
     dnsPolicy = Field(str, "ClusterFirst")
+    dnsConfig = Field(PodDNSConfig, None)
     nodeName = Field(str)
     nodeSelector = Field(dict)
     selector = Field(dict)

--- a/tests/k8s/test_pod.py
+++ b/tests/k8s/test_pod.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8
 
 # Copyright 2017-2019 The FIAAS Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,8 +20,17 @@ import pytest
 
 from k8s.client import NotFound
 from k8s.models.common import ObjectMeta
-from k8s.models.pod import Pod, ContainerPort, Container, LocalObjectReference, PodSpec, Volume, VolumeMount, \
-    SecretVolumeSource
+from k8s.models.pod import (
+    Pod,
+    ContainerPort,
+    Container,
+    LocalObjectReference,
+    PodSpec,
+    PodDNSConfig,
+    Volume,
+    VolumeMount,
+    SecretVolumeSource,
+)
 
 NAME = "my-name"
 NAMESPACE = "my-namespace"
@@ -34,6 +43,14 @@ class TestPod(object):
         pod = _create_pod()
         assert pod.metadata.name == NAME
         assert pod.as_dict()["metadata"]["name"] == NAME
+        assert "dnsOptions" not in pod.as_dict()["spec"]
+
+    def test_create_pod_with_dns_options(self):
+        pod = _create_pod()
+        pod.spec.dnsConfig = PodDNSConfig(
+            searches=["other-namespace.svc.cluster.local"],
+        )
+        assert pod.as_dict()["spec"]["dnsConfig"]["searches"] == ["other-namespace.svc.cluster.local"]
 
     def test_pod_created_if_not_exists(self, post, api_get):
         api_get.side_effect = NotFound()


### PR DESCRIPTION
It seems lists are always defaulted to [] and I didn't see any current way of avoiding that, added one.
I don't want to send [] in this case since I'm not certain that's the same as unset for nameservers.

Internal ticket: CDX-24